### PR TITLE
Scripts improvement

### DIFF
--- a/script/08_Lenses.s.sol
+++ b/script/08_Lenses.s.sol
@@ -51,3 +51,113 @@ contract Lenses is ScriptUtils {
         utilsLens = address(new UtilsLens());
     }
 }
+
+contract LensAccountDeployer is ScriptUtils {
+    function run() public broadcast returns (address accountLens) {
+        string memory outputScriptFileName = "08_LensAccount_output.json";
+
+        accountLens = execute();
+
+        string memory object;
+        object = vm.serializeAddress("lens", "accountLens", accountLens);
+        vm.writeJson(object, string.concat(vm.projectRoot(), "/script/", outputScriptFileName));
+    }
+
+    function deploy() public broadcast returns (address accountLens) {
+        accountLens = address(new AccountLens());
+    }
+
+    function execute() public returns (address accountLens) {
+        accountLens = address(new AccountLens());
+    }
+}
+
+contract LensOracleDeployer is ScriptUtils {
+    function run() public broadcast returns (address oracleLens) {
+        string memory inputScriptFileName = "08_LensOracle_input.json";
+        string memory outputScriptFileName = "08_LensOracle_output.json";
+        string memory json = getInputConfig(inputScriptFileName);
+        address oracleAdapterRegistry = abi.decode(vm.parseJson(json, ".oracleAdapterRegistry"), (address));
+
+        oracleLens = execute(oracleAdapterRegistry);
+
+        string memory object;
+        object = vm.serializeAddress("lens", "oracleLens", oracleLens);
+        vm.writeJson(object, string.concat(vm.projectRoot(), "/script/", outputScriptFileName));
+    }
+
+    function deploy(address oracleAdapterRegistry) public broadcast returns (address oracleLens) {
+        oracleLens = execute(oracleAdapterRegistry);
+    }
+
+    function execute(address oracleAdapterRegistry) public returns (address oracleLens) {
+        oracleLens = address(new OracleLens(oracleAdapterRegistry));
+    }
+}
+
+contract LensIRMDeployer is ScriptUtils {
+    function run() public broadcast returns (address irmLens) {
+        string memory inputScriptFileName = "08_LensIRM_input.json";
+        string memory outputScriptFileName = "08_LensIRM_output.json";
+        string memory json = getInputConfig(inputScriptFileName);
+        address kinkIRMFactory = abi.decode(vm.parseJson(json, ".kinkIRMFactory"), (address));
+
+        irmLens = execute(kinkIRMFactory);
+
+        string memory object;
+        object = vm.serializeAddress("lens", "irmLens", irmLens);
+        vm.writeJson(object, string.concat(vm.projectRoot(), "/script/", outputScriptFileName));
+    }
+
+    function deploy(address kinkIRMFactory) public broadcast returns (address irmLens) {
+        irmLens = execute(kinkIRMFactory);
+    }
+
+    function execute(address kinkIRMFactory) public returns (address irmLens) {
+        irmLens = address(new IRMLens(kinkIRMFactory));
+    }
+}
+
+contract LensVaultDeployer is ScriptUtils {
+    function run() public broadcast returns (address vaultLens) {
+        string memory inputScriptFileName = "08_LensVault_input.json";
+        string memory outputScriptFileName = "08_LensVault_output.json";
+        string memory json = getInputConfig(inputScriptFileName);
+        address oracleLens = abi.decode(vm.parseJson(json, ".oracleLens"), (address));
+        address irmLens = abi.decode(vm.parseJson(json, ".irmLens"), (address));
+
+        vaultLens = execute(oracleLens, irmLens);
+
+        string memory object;
+        object = vm.serializeAddress("lens", "vaultLens", vaultLens);
+        vm.writeJson(object, string.concat(vm.projectRoot(), "/script/", outputScriptFileName));
+    }
+
+    function deploy(address oracleLens, address irmLens) public broadcast returns (address vaultLens) {
+        vaultLens = execute(oracleLens, irmLens);
+    }
+
+    function execute(address oracleLens, address irmLens) public returns (address vaultLens) {
+        vaultLens = address(new VaultLens(oracleLens, irmLens));
+    }
+}
+
+contract LensUtilsDeployer is ScriptUtils {
+    function run() public broadcast returns (address utilsLens) {
+        string memory outputScriptFileName = "08_LensUtils_output.json";
+
+        utilsLens = execute();
+
+        string memory object;
+        object = vm.serializeAddress("lens", "utilsLens", utilsLens);
+        vm.writeJson(object, string.concat(vm.projectRoot(), "/script/", outputScriptFileName));
+    }
+
+    function deploy() public broadcast returns (address utilsLens) {
+        utilsLens = execute();
+    }
+
+    function execute() public returns (address utilsLens) {
+        utilsLens = address(new UtilsLens());
+    }
+}

--- a/script/interactiveDeployment.sh
+++ b/script/interactiveDeployment.sh
@@ -527,21 +527,97 @@ while true; do
             ;;
         8)
             echo "Deploying lenses..."
+            echo "Select the type of lens to deploy:"
+            echo "0. All (Account Lens, Oracle Lens, IRM Lens, Vault Lens, Utils Lens)"
+            echo "1. Account Lens"
+            echo "2. Vault Lens"
+            echo "3. Oracle Lens"
+            echo "4. IRM Lens"
+            echo "5. Utils Lens"
+            read -p "Enter your choice (0-5): " lens_choice
             
             baseName=08_Lenses
-            scriptName=${baseName}.s.sol
-            jsonName=$baseName
-            
-            read -p "Enter the Oracle Adapter Registry address: " oracle_adapter_registry
-            read -p "Enter the Kink IRM Factory address: " kink_irm_factory
 
-            jq -n \
-                --arg oracleAdapterRegistry "$oracle_adapter_registry" \
-                --arg kinkIRMFactory "$kink_irm_factory" \
-                '{
-                    oracleAdapterRegistry: $oracleAdapterRegistry,
-                    kinkIRMFactory: $kinkIRMFactory
-                }' --indent 4 > script/${jsonName}_input.json
+            case $lens_choice in
+                0)
+                    echo "Deploying all lenses..."
+                    
+                    scriptName=${baseName}.s.sol:Lenses
+                    jsonName=08_Lenses
+
+                    read -p "Enter the Oracle Adapter Registry address: " oracle_adapter_registry
+                    read -p "Enter the Kink IRM Factory address: " kink_irm_factory
+
+                    jq -n \
+                        --arg oracleAdapterRegistry "$oracle_adapter_registry" \
+                        --arg kinkIRMFactory "$kink_irm_factory" \
+                        '{
+                            oracleAdapterRegistry: $oracleAdapterRegistry,
+                            kinkIRMFactory: $kinkIRMFactory
+                        }' --indent 4 > script/${jsonName}_input.json
+                    ;;
+                1)
+                    echo "Deploying Account Lens..."
+                    
+                    scriptName=${baseName}.s.sol:LensAccountDeployer
+                    jsonName=08_LensAccount
+                    ;;
+                2)
+                    echo "Deploying Vault Lens..."
+                    
+                    scriptName=${baseName}.s.sol:LensVaultDeployer
+                    jsonName=08_LensVault
+                    
+                    read -p "Enter the Oracle Lens address: " oracle_lens
+                    read -p "Enter the IRM Lens address: " irm_lens
+
+                    jq -n \
+                        --arg oracleLens "$oracle_lens" \
+                        --arg irmLens "$irm_lens" \
+                        '{
+                            oracleLens: $oracleLens,
+                            irmLens: $irmLens
+                        }' --indent 4 > script/${jsonName}_input.json
+                    ;;
+                3)
+                    echo "Deploying Oracle Lens..."
+
+                    scriptName=${baseName}.s.sol:LensOracleDeployer
+                    jsonName=08_LensOracle
+
+                    read -p "Enter the Oracle Adapter Registry address: " oracle_adapter_registry
+
+                    jq -n \
+                        --arg oracleAdapterRegistry "$oracle_adapter_registry" \
+                        '{
+                            oracleAdapterRegistry: $oracleAdapterRegistry
+                        }' --indent 4 > script/${jsonName}_input.json
+                    ;;
+                4)
+                    echo "Deploying IRM Lens..."
+
+                    scriptName=${baseName}.s.sol:LensIRMDeployer
+                    jsonName=08_LensIRM
+
+                    read -p "Enter the Kink IRM Factory address: " kink_irm_factory
+
+                    jq -n \
+                        --arg kinkIRMFactory "$kink_irm_factory" \
+                        '{
+                            kinkIRMFactory: $kinkIRMFactory
+                        }' --indent 4 > script/${jsonName}_input.json
+                    ;;
+                5)
+                    echo "Deploying Utils Lens..."
+
+                    scriptName=${baseName}.s.sol:LensUtilsDeployer
+                    jsonName=08_LensUtils
+                    ;;
+                *)
+                    echo "Invalid lens choice. Exiting."
+                    exit 1
+                    ;;
+            esac            
             ;;
         9)
             echo "Deploying Perspectives..."

--- a/script/interactiveDeployment.sh
+++ b/script/interactiveDeployment.sh
@@ -19,6 +19,8 @@ function save_results {
     fi
 }
 
+source .env
+
 echo ""
 echo "Welcome to the deployment script!"
 echo "This script will guide you through the deployment process."
@@ -719,6 +721,6 @@ while true; do
             ;;
     esac
 
-    script/utils/executeForgeScript.sh $scriptName $verify_contracts --broadcast
+    script/utils/executeForgeScript.sh $scriptName $verify_contracts
     save_results $jsonName "$deployment_name"
 done

--- a/script/production/ConfigWhitelistGovernedPerspective.sh
+++ b/script/production/ConfigWhitelistGovernedPerspective.sh
@@ -61,8 +61,12 @@ if [[ "$@" == *"--dry-run"* ]]; then
 fi
 
 echo "Executing batch transaction..."
-currentGasPrice=$(cast gas-price --rpc-url "$DEPLOYMENT_RPC_URL")
-gasPrice=$(echo "if ($currentGasPrice * 1.25 > 2000000000) ($currentGasPrice * 1.25)/1 else 2000000000" | bc)
+chainId=$(cast chain-id --rpc-url $DEPLOYMENT_RPC_URL)
+gasPrice=$(echo "($(cast gas-price --rpc-url "$DEPLOYMENT_RPC_URL") * 1.25)/1" | bc)
+
+if [[ $chainId == "1" ]]; then
+    gasPrice=$(echo "if ($gasPrice > 2000000000) $gasPrice else 2000000000" | bc)
+fi
 
 if cast send $evc "batch((address,address,uint256,bytes)[])" $items --rpc-url $DEPLOYMENT_RPC_URL --private-key $DEPLOYER_KEY --legacy --gas-price $gasPrice; then
     echo "Batch transaction successful."

--- a/script/production/ConfigWhitelistOracleAdapters.sh
+++ b/script/production/ConfigWhitelistOracleAdapters.sh
@@ -79,8 +79,12 @@ if [[ "$@" == *"--dry-run"* ]]; then
 fi
 
 echo "Executing batch transaction..."
-currentGasPrice=$(cast gas-price --rpc-url "$DEPLOYMENT_RPC_URL")
-gasPrice=$(echo "if ($currentGasPrice * 1.25 > 2000000000) ($currentGasPrice * 1.25)/1 else 2000000000" | bc)
+chainId=$(cast chain-id --rpc-url $DEPLOYMENT_RPC_URL)
+gasPrice=$(echo "($(cast gas-price --rpc-url "$DEPLOYMENT_RPC_URL") * 1.25)/1" | bc)
+
+if [[ $chainId == "1" ]]; then
+    gasPrice=$(echo "if ($gasPrice > 2000000000) $gasPrice else 2000000000" | bc)
+fi
 
 if cast send $evc "batch((address,address,uint256,bytes)[])" $items --rpc-url $DEPLOYMENT_RPC_URL --private-key $DEPLOYER_KEY --legacy --gas-price $gasPrice; then
     echo "Batch transaction successful."

--- a/script/production/DeployOracleAdapters.sh
+++ b/script/production/DeployOracleAdapters.sh
@@ -40,6 +40,10 @@ csv_oracle_adapters_addresses_path="$2"
 read -p "Do you want to verify the deployed contracts? (y/n) (default: n): " verify_contracts
 verify_contracts=${verify_contracts:-n}
 
+if [[ $verify_contracts == "y" ]]; then
+    verify_contracts="--verify"
+fi
+
 if ! script/utils/checkEnvironment.sh $verify_contracts; then
     echo "Environment check failed. Exiting."
     exit 1
@@ -346,7 +350,7 @@ while IFS=, read -r -a columns || [ -n "$columns" ]; do
         continue
     fi
 
-    script/utils/executeForgeScript.sh $scriptName $verify_contracts
+    script/utils/executeForgeScript.sh $scriptName $verify_contracts --broadcast
 
     if [[ -f "script/${jsonName}_output.json" ]]; then
         counter=$(script/utils/getFileNameCounter.sh "$deployment_dir/input/${jsonName}.json")

--- a/script/production/DeployOracleAdapters.sh
+++ b/script/production/DeployOracleAdapters.sh
@@ -100,6 +100,15 @@ while IFS=, read -r -a columns || [ -n "$columns" ]; do
         adapterName="${provider// /}_${baseSymbol}/${quoteSymbol}"
     fi
 
+    for i in "${!columns[@]}"; do
+        stripped=$(echo "${columns[$i]}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+        if [[ "$stripped" != "${columns[$i]}" ]]; then
+            echo "Skipping deployment of $adapterName. Whitespace detected in column $i"
+            continue
+        fi
+    done
+
     if [[ "$avoid_duplicates" == "y" ]]; then
         adapterAddress=$(find_adapter_address "$adapterName" "$csv_oracle_adapters_addresses_path")
 

--- a/script/production/DeployOracleAdapters.sh
+++ b/script/production/DeployOracleAdapters.sh
@@ -350,7 +350,7 @@ while IFS=, read -r -a columns || [ -n "$columns" ]; do
         continue
     fi
 
-    script/utils/executeForgeScript.sh $scriptName $verify_contracts --broadcast
+    script/utils/executeForgeScript.sh $scriptName $verify_contracts
 
     if [[ -f "script/${jsonName}_output.json" ]]; then
         counter=$(script/utils/getFileNameCounter.sh "$deployment_dir/input/${jsonName}.json")

--- a/script/production/ExecuteSolidityScript.sh
+++ b/script/production/ExecuteSolidityScript.sh
@@ -6,7 +6,8 @@ if [ -z "$1" ]; then
 fi
 
 source .env
-scriptPath="${1#script/}"
+scriptPath="${1#./}"
+scriptPath="${scriptPath#script/}"
 scriptName=$(basename "$1")
 
 read -p "Do you want to verify the deployed contracts? (y/n) (default: n): " verify_contracts

--- a/script/production/ExecuteSolidityScript.sh
+++ b/script/production/ExecuteSolidityScript.sh
@@ -9,8 +9,17 @@ source .env
 scriptPath="${1#script/}"
 scriptName=$(basename "$1")
 
+broadcast="--broadcast"
+if [[ "$@" == *"--dry-run"* ]]; then
+    broadcast=""
+fi
+
 read -p "Do you want to verify the deployed contracts? (y/n) (default: n): " verify_contracts
 verify_contracts=${verify_contracts:-n}
+
+if [[ $verify_contracts == "y" ]]; then
+    verify_contracts="--verify"
+fi
 
 read -p "Provide the deployment name used to save results (default: default): " deployment_name
 deployment_name=${deployment_name:-default}
@@ -20,7 +29,7 @@ if ! script/utils/checkEnvironment.sh $verify_contracts; then
     exit 1
 fi
 
-if script/utils/executeForgeScript.sh "$scriptPath" $verify_contracts; then
+if script/utils/executeForgeScript.sh "$scriptPath" $verify_contracts $broadcast; then
     deployment_dir="script/deployments/$deployment_name"
     chainId=$(cast chain-id --rpc-url $DEPLOYMENT_RPC_URL)
 

--- a/script/utils/AccountLensCall.s.sol
+++ b/script/utils/AccountLensCall.s.sol
@@ -2,15 +2,14 @@
 
 pragma solidity ^0.8.0;
 
-import "forge-std/Script.sol";
+import {ScriptUtils} from "./ScriptUtils.s.sol";
 import {AccountLens} from "../../src/Lens/AccountLens.sol";
 import "../../src/Lens/LensTypes.sol";
 
-contract AccountLensCall is Script {
+contract AccountLensCall is ScriptUtils {
     function run() public view returns (VaultAccountInfo memory) {
-        address lens = vm.envAddress("VAULT_LENS_ADDRESS");
-        address account = vm.envAddress("ACCOUNT_ADDRESS");
-        address vault = vm.envAddress("VAULT_ADDRESS");
-        return AccountLens(lens).getVaultAccountInfo(account, vault);
+        return AccountLens(lensAddresses.accountLens).getVaultAccountInfo(
+            vm.envAddress("ACCOUNT_ADDRESS"), vm.envAddress("VAULT_ADDRESS")
+        );
     }
 }

--- a/script/utils/ScriptUtils.s.sol
+++ b/script/utils/ScriptUtils.s.sol
@@ -187,7 +187,11 @@ abstract contract ScriptUtils is CoreAddressesLib, PeripheryAddressesLib, LensAd
 
     function getAddressesJson(string memory jsonFile) internal view returns (string memory) {
         string memory addressesDirPath = vm.envOr("ADDRESSES_DIR_PATH", string(""));
-        if (bytes(addressesDirPath).length == 0) return "";
+
+        if (bytes(addressesDirPath).length == 0) {
+            revert("getAddressesJson: ADDRESSES_DIR_PATH environment variable is not set");
+        }
+
         return vm.readFile(string.concat(addressesDirPath, "/", jsonFile));
     }
 

--- a/script/utils/ScriptUtils.s.sol
+++ b/script/utils/ScriptUtils.s.sol
@@ -12,9 +12,17 @@ import {IEVault} from "evk/EVault/IEVault.sol";
 import {EulerRouter} from "euler-price-oracle/EulerRouter.sol";
 import {BasePerspective} from "../../src/Perspectives/implementation/BasePerspective.sol";
 
-import "forge-std/console.sol";
+abstract contract ScriptExtended is Script {
+    function getAddressFromJson(string memory json, string memory key) internal pure returns (address) {
+        try vm.parseJsonAddress(json, key) returns (address result) {
+            return result;
+        } catch {
+            revert(string(abi.encodePacked("getAddressFromJson: failed to parse JSON for key: ", key)));
+        }
+    }
+}
 
-abstract contract CoreAddressesLib is Script {
+abstract contract CoreAddressesLib is ScriptExtended {
     struct CoreAddresses {
         address evc;
         address protocolConfig;
@@ -37,23 +45,21 @@ abstract contract CoreAddressesLib is Script {
         result = vm.serializeAddress("coreAddresses", "eVaultFactoryGovernor", Addresses.eVaultFactoryGovernor);
     }
 
-    function deserializeCoreAddresses(string memory json) internal pure returns (CoreAddresses memory result) {
-        if (bytes(json).length == 0) return result;
-
-        result = CoreAddresses({
-            evc: abi.decode(vm.parseJson(json, ".evc"), (address)),
-            protocolConfig: abi.decode(vm.parseJson(json, ".protocolConfig"), (address)),
-            sequenceRegistry: abi.decode(vm.parseJson(json, ".sequenceRegistry"), (address)),
-            balanceTracker: abi.decode(vm.parseJson(json, ".balanceTracker"), (address)),
-            permit2: abi.decode(vm.parseJson(json, ".permit2"), (address)),
-            eVaultImplementation: abi.decode(vm.parseJson(json, ".eVaultImplementation"), (address)),
-            eVaultFactory: abi.decode(vm.parseJson(json, ".eVaultFactory"), (address)),
-            eVaultFactoryGovernor: abi.decode(vm.parseJson(json, ".eVaultFactoryGovernor"), (address))
+    function deserializeCoreAddresses(string memory json) internal pure returns (CoreAddresses memory) {
+        return CoreAddresses({
+            evc: getAddressFromJson(json, ".evc"),
+            protocolConfig: getAddressFromJson(json, ".protocolConfig"),
+            sequenceRegistry: getAddressFromJson(json, ".sequenceRegistry"),
+            balanceTracker: getAddressFromJson(json, ".balanceTracker"),
+            permit2: getAddressFromJson(json, ".permit2"),
+            eVaultImplementation: getAddressFromJson(json, ".eVaultImplementation"),
+            eVaultFactory: getAddressFromJson(json, ".eVaultFactory"),
+            eVaultFactoryGovernor: getAddressFromJson(json, ".eVaultFactoryGovernor")
         });
     }
 }
 
-abstract contract PeripheryAddressesLib is Script {
+abstract contract PeripheryAddressesLib is ScriptExtended {
     struct PeripheryAddresses {
         address oracleRouterFactory;
         address oracleAdapterRegistry;
@@ -92,32 +98,26 @@ abstract contract PeripheryAddressesLib is Script {
         );
     }
 
-    function deserializePeripheryAddresses(string memory json)
-        internal
-        pure
-        returns (PeripheryAddresses memory result)
-    {
-        if (bytes(json).length == 0) return result;
-
-        result = PeripheryAddresses({
-            oracleRouterFactory: abi.decode(vm.parseJson(json, ".oracleRouterFactory"), (address)),
-            oracleAdapterRegistry: abi.decode(vm.parseJson(json, ".oracleAdapterRegistry"), (address)),
-            externalVaultRegistry: abi.decode(vm.parseJson(json, ".externalVaultRegistry"), (address)),
-            kinkIRMFactory: abi.decode(vm.parseJson(json, ".kinkIRMFactory"), (address)),
-            irmRegistry: abi.decode(vm.parseJson(json, ".irmRegistry"), (address)),
-            swapper: abi.decode(vm.parseJson(json, ".swapper"), (address)),
-            swapVerifier: abi.decode(vm.parseJson(json, ".swapVerifier"), (address)),
-            feeFlowController: abi.decode(vm.parseJson(json, ".feeFlowController"), (address)),
-            evkFactoryPerspective: abi.decode(vm.parseJson(json, ".evkFactoryPerspective"), (address)),
-            governedPerspective: abi.decode(vm.parseJson(json, ".governedPerspective"), (address)),
-            escrowedCollateralPerspective: abi.decode(vm.parseJson(json, ".escrowedCollateralPerspective"), (address)),
-            eulerUngoverned0xPerspective: abi.decode(vm.parseJson(json, ".eulerUngoverned0xPerspective"), (address)),
-            eulerUngovernedNzxPerspective: abi.decode(vm.parseJson(json, ".eulerUngovernedNzxPerspective"), (address))
+    function deserializePeripheryAddresses(string memory json) internal pure returns (PeripheryAddresses memory) {
+        return PeripheryAddresses({
+            oracleRouterFactory: getAddressFromJson(json, ".oracleRouterFactory"),
+            oracleAdapterRegistry: getAddressFromJson(json, ".oracleAdapterRegistry"),
+            externalVaultRegistry: getAddressFromJson(json, ".externalVaultRegistry"),
+            kinkIRMFactory: getAddressFromJson(json, ".kinkIRMFactory"),
+            irmRegistry: getAddressFromJson(json, ".irmRegistry"),
+            swapper: getAddressFromJson(json, ".swapper"),
+            swapVerifier: getAddressFromJson(json, ".swapVerifier"),
+            feeFlowController: getAddressFromJson(json, ".feeFlowController"),
+            evkFactoryPerspective: getAddressFromJson(json, ".evkFactoryPerspective"),
+            governedPerspective: getAddressFromJson(json, ".governedPerspective"),
+            escrowedCollateralPerspective: getAddressFromJson(json, ".escrowedCollateralPerspective"),
+            eulerUngoverned0xPerspective: getAddressFromJson(json, ".eulerUngoverned0xPerspective"),
+            eulerUngovernedNzxPerspective: getAddressFromJson(json, ".eulerUngovernedNzxPerspective")
         });
     }
 }
 
-abstract contract LensAddressesLib is Script {
+abstract contract LensAddressesLib is ScriptExtended {
     struct LensAddresses {
         address accountLens;
         address oracleLens;
@@ -134,20 +134,18 @@ abstract contract LensAddressesLib is Script {
         result = vm.serializeAddress("lensAddresses", "utilsLens", Addresses.utilsLens);
     }
 
-    function deserializeLensAddresses(string memory json) internal pure returns (LensAddresses memory result) {
-        if (bytes(json).length == 0) return result;
-
-        result = LensAddresses({
-            accountLens: abi.decode(vm.parseJson(json, ".accountLens"), (address)),
-            oracleLens: abi.decode(vm.parseJson(json, ".oracleLens"), (address)),
-            irmLens: abi.decode(vm.parseJson(json, ".irmLens"), (address)),
-            vaultLens: abi.decode(vm.parseJson(json, ".vaultLens"), (address)),
-            utilsLens: abi.decode(vm.parseJson(json, ".utilsLens"), (address))
+    function deserializeLensAddresses(string memory json) internal pure returns (LensAddresses memory) {
+        return LensAddresses({
+            accountLens: getAddressFromJson(json, ".accountLens"),
+            oracleLens: getAddressFromJson(json, ".oracleLens"),
+            irmLens: getAddressFromJson(json, ".irmLens"),
+            vaultLens: getAddressFromJson(json, ".vaultLens"),
+            utilsLens: getAddressFromJson(json, ".utilsLens")
         });
     }
 }
 
-abstract contract ScriptUtils is Script, CoreAddressesLib, PeripheryAddressesLib, LensAddressesLib {
+abstract contract ScriptUtils is CoreAddressesLib, PeripheryAddressesLib, LensAddressesLib {
     CoreAddresses internal coreAddresses;
     PeripheryAddresses internal peripheryAddresses;
     LensAddresses internal lensAddresses;

--- a/script/utils/VaultLensCall.s.sol
+++ b/script/utils/VaultLensCall.s.sol
@@ -2,14 +2,12 @@
 
 pragma solidity ^0.8.0;
 
-import "forge-std/Script.sol";
+import {ScriptUtils} from "./ScriptUtils.s.sol";
 import {VaultLens} from "../../src/Lens/VaultLens.sol";
 import "../../src/Lens/LensTypes.sol";
 
-contract VaultLensCall is Script {
+contract VaultLensCall is ScriptUtils {
     function run() public view returns (VaultInfoFull memory) {
-        address lens = vm.envAddress("VAULT_LENS_ADDRESS");
-        address vault = vm.envAddress("VAULT_ADDRESS");
-        return VaultLens(lens).getVaultInfoFull(vault);
+        return VaultLens(lensAddresses.vaultLens).getVaultInfoFull(vm.envAddress("VAULT_ADDRESS"));
     }
 }

--- a/script/utils/VerifyFactoryProxies.sh
+++ b/script/utils/VerifyFactoryProxies.sh
@@ -7,7 +7,8 @@ fi
 
 source .env
 
-read -p "Enter the EVK Factory Perspective address: " factory_perspective
+addresses_dir_path="${ADDRESSES_DIR_PATH%/}"
+factory_perspective=$(jq -r '.evkFactoryPerspective' "$addresses_dir_path/PeripheryAddresses.json")
 
 factoryVaults=$(cast call $factory_perspective "verifiedArray()(address[])" --rpc-url $DEPLOYMENT_RPC_URL)
 factoryVaults=($(echo "$factoryVaults" | sed 's/[][]//g' | tr ',' '\n'))
@@ -15,4 +16,5 @@ factoryVaults=($(echo "$factoryVaults" | sed 's/[][]//g' | tr ',' '\n'))
 for contractAddress in "${factoryVaults[@]}"; do
     echo "Verifying proxy contract for address: $contractAddress"
     curl -d "address=$contractAddress" "$VERIFIER_URL?module=contract&action=verifyproxycontract&apikey=$VERIFIER_API_KEY"
+    echo ""
 done

--- a/script/utils/checkEnvironment.sh
+++ b/script/utils/checkEnvironment.sh
@@ -2,8 +2,6 @@
 
 source .env
 
-shouldVerify=$1
-
 if ! command -v jq &> /dev/null; then
     echo "jq could not be found. Please install jq first."
     echo "You can install jq by running: sudo apt-get install jq"
@@ -15,7 +13,7 @@ if [ -z "$DEPLOYMENT_RPC_URL" ]; then
     exit 1
 fi
 
-if [[ $shouldVerify == "y" ]]; then
+if [[ "$@" == *"--verify"* ]]; then
     if [ -z "$VERIFIER_URL" ]; then
         echo "Error: VERIFIER_URL environment variable is not set. Please set it and try again."
         exit 1

--- a/script/utils/executeForgeScript.sh
+++ b/script/utils/executeForgeScript.sh
@@ -4,11 +4,16 @@ source .env
 
 scriptPath=$1
 
-currentGasPrice=$(cast gas-price --rpc-url "$DEPLOYMENT_RPC_URL")
-gasPrice=$(echo "if ($currentGasPrice * 1.25 > 2000000000) ($currentGasPrice * 1.25)/1 else 2000000000" | bc)
+chainId=$(cast chain-id --rpc-url $DEPLOYMENT_RPC_URL)
+gasPrice=$(echo "($(cast gas-price --rpc-url "$DEPLOYMENT_RPC_URL") * 1.25)/1" | bc)
 
-if [[ "$@" == *"--broadcast"* ]]; then
-    broadcast="--broadcast"
+if [[ $chainId == "1" ]]; then
+    gasPrice=$(echo "if ($gasPrice > 2000000000) $gasPrice else 2000000000" | bc)
+fi
+
+broadcast="--broadcast"
+if [[ "$@" == *"--dry-run"* ]]; then
+    broadcast=""
 fi
 
 if ! forge script script/$scriptPath --rpc-url "$DEPLOYMENT_RPC_URL" $broadcast --legacy --slow --with-gas-price $gasPrice; then
@@ -16,7 +21,6 @@ if ! forge script script/$scriptPath --rpc-url "$DEPLOYMENT_RPC_URL" $broadcast 
 fi
 
 if [[ "$@" == *"--verify"* ]]; then
-    chainId=$(cast chain-id --rpc-url $DEPLOYMENT_RPC_URL)
     broadcastFileName=$(basename "${scriptPath%%:*}")
 
     script/utils/verifyContracts.sh "broadcast/$broadcastFileName/$chainId/run-latest.json"

--- a/script/utils/executeForgeScript.sh
+++ b/script/utils/executeForgeScript.sh
@@ -3,16 +3,19 @@
 source .env
 
 scriptPath=$1
-shouldVerify=$2
 
 currentGasPrice=$(cast gas-price --rpc-url "$DEPLOYMENT_RPC_URL")
 gasPrice=$(echo "if ($currentGasPrice * 1.25 > 2000000000) ($currentGasPrice * 1.25)/1 else 2000000000" | bc)
 
-if ! forge script script/$scriptPath --rpc-url "$DEPLOYMENT_RPC_URL" --broadcast --legacy --slow --with-gas-price $gasPrice; then
+if [[ "$@" == *"--broadcast"* ]]; then
+    broadcast="--broadcast"
+fi
+
+if ! forge script script/$scriptPath --rpc-url "$DEPLOYMENT_RPC_URL" $broadcast --legacy --slow --with-gas-price $gasPrice; then
     exit 1
 fi
 
-if [[ $shouldVerify == "y" ]]; then
+if [[ "$@" == *"--verify"* ]]; then
     chainId=$(cast chain-id --rpc-url $DEPLOYMENT_RPC_URL)
     broadcastFileName=$(basename "${scriptPath%%:*}")
 

--- a/script/utils/verifyContracts.sh
+++ b/script/utils/verifyContracts.sh
@@ -17,6 +17,10 @@ function verify_broadcast {
     local transactions=$(jq -c '.transactions[]' $tmpFileName)
     rm $tmpFileName
 
+    if [ $(echo "$transactions" | wc -l) -eq 1 ]; then
+        sleep 5
+    fi
+
     for tx in $transactions; do
         local transactionType=$(echo $tx | jq -r '.transactionType')
         local contractAddress=$(echo $tx | jq -r '.contractAddress')


### PR DESCRIPTION
- allows to deploy lenses separately from the interactive script (no more comment outs)
- applies 2gwei gas floor only on mainnet
- skips deployment of an oracle adapter if a whitespace is detected in any of the CSV columns
- adds --dry-run for ExecuteSolidityScript.sh
- if only once contract deployed, sleep for a few seconds before trying to verify it