### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/docs/swaps.md
+++ b/docs/swaps.md
@@ -45,7 +45,7 @@ Finally a `multicall` function allows chaining all of the above to execute compl
 The swaps can be performed in one of 3 modes:
 - exact input 
 
-  In this mode, all of the provided input token is expected to be swapped for an unknown amount of the output token. The proceeds are expected to be sent to a vault, to be skimmed by the user, or back to the swapper contract. The latter option is useful when performing complex, multi-stage swaps, where the output token is accumulated in the swapper before being consumed at the end of the operation. Note that the available handler (`GenericHandler`) executes a payload encoded off-chain, so a lot of the parameters passed to the `swap` funtion will be ignored and only the amount of input token encoded in the payload will be swapped, even if the swapper holds more.
+  In this mode, all of the provided input token is expected to be swapped for an unknown amount of the output token. The proceeds are expected to be sent to a vault, to be skimmed by the user, or back to the swapper contract. The latter option is useful when performing complex, multi-stage swaps, where the output token is accumulated in the swapper before being consumed at the end of the operation. Note that the available handler (`GenericHandler`) executes a payload encoded off-chain, so a lot of the parameters passed to the `swap` function will be ignored and only the amount of input token encoded in the payload will be swapped, even if the swapper holds more.
 
 - exact output
 

--- a/test/Governor/FactoryGovernor.t.sol
+++ b/test/Governor/FactoryGovernor.t.sol
@@ -82,7 +82,7 @@ contract FactoryGovernorTests is EVaultTestBase {
         vm.expectRevert("contract is in read-only mode");
         eTST.deposit(1e18, depositor);
 
-        // admin can roll back changes by installing previous imlpementation
+        // admin can roll back changes by installing previous implementations
         vm.prank(admin);
         factoryGovernor.adminCall(address(factory), abi.encodeCall(factory.setImplementation, (oldImplementation)));
 


### PR DESCRIPTION
This PR fixes two minor typos:

1. In docs/swaps.md: Fixed "funtion" to "function" in the exact input mode description

2. In test/Governor/FactoryGovernor.t.sol: Fixed "implmentation" to "implementations" in the comment about admin rollback capability