### PR TITLE
feat: add dynamic market ops planner

### DIFF
--- a/script/production/ManageClusterBase.s.sol
+++ b/script/production/ManageClusterBase.s.sol
@@ -19,6 +19,7 @@ import "../../src/Lens/LensTypes.sol";
 abstract contract ManageClusterBase is BatchBuilder {
     struct Cluster {
         string clusterAddressesPath;
+        bool clusterAddressesPathAbsolute;
         address oracleRoutersGovernor;
         address vaultsGovernor;
         address[] assets;
@@ -693,7 +694,7 @@ abstract contract ManageClusterBase is BatchBuilder {
         result = vm.serializeAddress("cluster", "externalVaults", cluster.externalVaults);
         result = vm.serializeAddress("cluster", "stubOracle", cluster.stubOracle);
 
-        vm.writeJson(result, string.concat(vm.projectRoot(), "/script/Cluster.json"));
+        vm.writeJson(result, getScriptOutputFilePath("Cluster.json"));
 
         if (isBroadcast()) {
             if (!_strEq(cluster.clusterAddressesPath, "")) vm.writeJson(result, cluster.clusterAddressesPath);
@@ -706,7 +707,9 @@ abstract contract ManageClusterBase is BatchBuilder {
 
     function loadCluster() private {
         if (!_strEq(cluster.clusterAddressesPath, "")) {
-            cluster.clusterAddressesPath = string.concat(vm.projectRoot(), cluster.clusterAddressesPath);
+            if (!cluster.clusterAddressesPathAbsolute) {
+                cluster.clusterAddressesPath = string.concat(vm.projectRoot(), cluster.clusterAddressesPath);
+            }
 
             if (vm.exists(cluster.clusterAddressesPath)) {
                 string memory json = vm.readFile(cluster.clusterAddressesPath);

--- a/script/production/market-ops/DynamicCluster.s.sol
+++ b/script/production/market-ops/DynamicCluster.s.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.0;
+
+import {ManageClusterBase} from "../ManageClusterBase.s.sol";
+import {DynamicClusterInputLib} from "./DynamicClusterInput.s.sol";
+
+contract DynamicCluster is ManageClusterBase {
+    DynamicClusterInputLib.Input private input;
+    bytes32 private inputHash;
+    string private routeKind;
+
+    function getDeployer() internal view override returns (address) {
+        return input.deployer == address(0) ? vm.envAddress("MARKET_OPS_DEPLOYER") : input.deployer;
+    }
+
+    function defineCluster() internal override {
+        string memory inputPath = vm.envString("MARKET_OPS_CLUSTER_INPUT");
+        (input, inputHash) = DynamicClusterInputLib.read(vm, inputPath);
+
+        require(input.chainId == block.chainid, "DynamicCluster: chain mismatch");
+        require(input.blockNumber == block.number, "DynamicCluster: block mismatch");
+        require(input.deployer == vm.envAddress("MARKET_OPS_DEPLOYER"), "DynamicCluster: deployer mismatch");
+        routeKind = vm.envString("MARKET_OPS_ROUTE_KIND");
+        _validateRoute();
+
+        cluster.clusterAddressesPath = getScriptOutputFilePath("ClusterAddresses.json");
+        cluster.clusterAddressesPathAbsolute = true;
+        cluster.assets = input.assets;
+        cluster.vaults = input.vaults;
+        cluster.oracleRouters = input.oracleRouters;
+        cluster.irmsArr = input.irms;
+        cluster.externalVaults = input.externalVaults;
+        cluster.stubOracle = input.stubOracle;
+    }
+
+    function configureCluster() internal override {
+        setNoStubOracle(input.noStubOracle);
+        cluster.oracleRoutersGovernor = input.oracleRoutersGovernor;
+        cluster.vaultsGovernor = input.vaultsGovernor;
+        cluster.unitOfAccount = input.unitOfAccount;
+        cluster.feeReceiver = input.feeReceiver;
+        cluster.interestFee = input.interestFee;
+        cluster.maxLiquidationDiscount = input.maxLiquidationDiscount;
+        cluster.liquidationCoolOffTime = input.liquidationCoolOffTime;
+        cluster.hookTarget = input.hookTarget;
+        cluster.hookedOps = input.hookedOps;
+        cluster.configFlags = input.configFlags;
+        cluster.forceZeroGovernors = input.forceZeroGovernors;
+        cluster.rampDuration = input.rampDuration;
+        cluster.spreadLTV = input.spreadLTV;
+        cluster.ltvs = input.ltvs;
+        cluster.borrowLTVsOverride = input.borrowLTVsOverride;
+        cluster.spreadLTVOverride = input.spreadLTVOverride;
+        cluster.externalLTVs = input.externalLTVs;
+        cluster.externalBorrowLTVsOverride = input.externalBorrowLTVsOverride;
+        cluster.externalSpreadLTVsOverride = input.externalSpreadLTVsOverride;
+
+        for (uint256 i = 0; i < input.oracleProviderBases.length; ++i) {
+            cluster.oracleProviders[input.oracleProviderBases[i]] = input.oracleProviders[i];
+        }
+
+        for (uint256 i = 0; i < input.assets.length; ++i) {
+            address asset = input.assets[i];
+            cluster.supplyCaps[asset] = input.supplyCaps[i];
+            cluster.borrowCaps[asset] = input.borrowCaps[i];
+            cluster.feeReceiverOverride[asset] = input.feeReceiverOverrides[i];
+            cluster.interestFeeOverride[asset] = input.interestFeeOverrides[i];
+            cluster.maxLiquidationDiscountOverride[asset] = input.maxLiquidationDiscountOverrides[i];
+            cluster.liquidationCoolOffTimeOverride[asset] = input.liquidationCoolOffTimeOverrides[i];
+            cluster.hookTargetOverride[asset] = input.hookTargetOverrides[i];
+            cluster.hookedOpsOverride[asset] = input.hookedOpsOverrides[i];
+            cluster.configFlagsOverride[asset] = input.configFlagsOverrides[i];
+            cluster.kinkIRMParams[asset] = input.kinkIRMParams[i];
+            cluster.irms[asset] = input.irms[i];
+        }
+    }
+
+    function postOperations() internal override {
+        bytes32 batchesHash =
+            keccak256(bytes(vm.readFile(getScriptOutputFilePath("Batches.json"))));
+        bytes32 clusterHash =
+            keccak256(bytes(vm.readFile(getScriptOutputFilePath("Cluster.json"))));
+        string memory manifest;
+        manifest = vm.serializeString("marketOps", "schema", DynamicClusterInputLib.SCHEMA);
+        manifest = vm.serializeString("marketOps", "requestHash", input.requestHash);
+        manifest = vm.serializeBytes32("marketOps", "inputHash", inputHash);
+        manifest = vm.serializeBytes32("marketOps", "batchesHash", batchesHash);
+        manifest = vm.serializeBytes32("marketOps", "clusterHash", clusterHash);
+        manifest = vm.serializeString("marketOps", "sourceCommit", input.sourceCommit);
+        manifest = vm.serializeUint("marketOps", "chainId", input.chainId);
+        manifest = vm.serializeUint("marketOps", "blockNumber", input.blockNumber);
+        manifest = vm.serializeBytes32("marketOps", "blockHash", input.blockHash);
+        manifest = vm.serializeAddress("marketOps", "deployer", input.deployer);
+        manifest = vm.serializeString("marketOps", "routeKind", routeKind);
+        manifest = vm.serializeAddress("marketOps", "safe", getSafe(false));
+        manifest = vm.serializeUint("marketOps", "safeNonce", safeNonce);
+        manifest = vm.serializeAddress("marketOps", "timelock", getTimelock());
+        manifest = vm.serializeAddress("marketOps", "riskSteward", getRiskSteward());
+        manifest = vm.serializeBool("marketOps", "emergency", isEmergency());
+        manifest = vm.serializeBool("marketOps", "broadcast", isBroadcast());
+        vm.writeJson(manifest, getScriptOutputFilePath("MarketOpsManifest.json"));
+    }
+
+    function _validateRoute() private view {
+        validateRouteConfig(
+            routeKind,
+            isBatchViaSafe(),
+            getSafe(false),
+            getTimelock(),
+            getRiskSteward(),
+            isEmergency()
+        );
+    }
+
+    function validateRouteConfig(
+        string memory kind,
+        bool viaSafe,
+        address safe,
+        address timelock,
+        address riskSteward,
+        bool emergency
+    ) internal pure {
+        if (_strEq(kind, "deployer-direct") || _strEq(kind, "direct")) {
+            require(!viaSafe && safe == address(0) && timelock == address(0) && riskSteward == address(0) && !emergency, "DynamicCluster: direct route");
+        } else if (_strEq(kind, "safe")) {
+            require(viaSafe && safe != address(0) && timelock == address(0) && riskSteward == address(0) && !emergency, "DynamicCluster: safe route");
+        } else if (_strEq(kind, "safe-timelock")) {
+            require(viaSafe && safe != address(0) && timelock != address(0) && safe != timelock && riskSteward == address(0) && !emergency, "DynamicCluster: safe timelock route");
+        } else if (_strEq(kind, "timelock")) {
+            require(!viaSafe && safe == address(0) && timelock != address(0) && riskSteward == address(0) && !emergency, "DynamicCluster: timelock route");
+        } else if (_strEq(kind, "risk-steward")) {
+            require(riskSteward != address(0) && (viaSafe == (safe != address(0))) && !emergency, "DynamicCluster: risk steward route");
+        } else if (_strEq(kind, "emergency")) {
+            require((viaSafe == (safe != address(0))) && emergency, "DynamicCluster: emergency route");
+        } else {
+            revert("DynamicCluster: unsupported route");
+        }
+    }
+}

--- a/script/production/market-ops/DynamicClusterInput.s.sol
+++ b/script/production/market-ops/DynamicClusterInput.s.sol
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.0;
+
+import {Vm} from "forge-std/Vm.sol";
+
+library DynamicClusterInputLib {
+    string internal constant SCHEMA = "evk-market-ops-cluster-input-v1";
+
+    struct Input {
+        string schema;
+        string requestHash;
+        string sourceCommit;
+        uint256 chainId;
+        uint256 blockNumber;
+        bytes32 blockHash;
+        address deployer;
+        address oracleRoutersGovernor;
+        address vaultsGovernor;
+        address[] assets;
+        address[] vaults;
+        address[] oracleRouters;
+        address[] irms;
+        address[] externalVaults;
+        address stubOracle;
+        bool noStubOracle;
+        address unitOfAccount;
+        address feeReceiver;
+        uint16 interestFee;
+        uint16 maxLiquidationDiscount;
+        uint16 liquidationCoolOffTime;
+        address hookTarget;
+        uint32 hookedOps;
+        uint32 configFlags;
+        bool forceZeroGovernors;
+        uint32 rampDuration;
+        uint16 spreadLTV;
+        address[] oracleProviderBases;
+        string[] oracleProviders;
+        uint256[] supplyCaps;
+        uint256[] borrowCaps;
+        address[] feeReceiverOverrides;
+        uint16[] interestFeeOverrides;
+        uint16[] maxLiquidationDiscountOverrides;
+        uint16[] liquidationCoolOffTimeOverrides;
+        address[] hookTargetOverrides;
+        uint32[] hookedOpsOverrides;
+        uint32[] configFlagsOverrides;
+        uint256[4][] kinkIRMParams;
+        uint16[][] ltvs;
+        uint16[][] borrowLTVsOverride;
+        uint16[][] spreadLTVOverride;
+        uint16[][] externalLTVs;
+        uint16[][] externalBorrowLTVsOverride;
+        uint16[][] externalSpreadLTVsOverride;
+    }
+
+    function read(Vm vm, string memory path) internal view returns (Input memory input, bytes32 inputHash) {
+        string memory json = vm.readFile(path);
+        inputHash = keccak256(bytes(json));
+
+        input.schema = vm.parseJsonString(json, ".schema");
+        require(keccak256(bytes(input.schema)) == keccak256(bytes(SCHEMA)), "DynamicClusterInput: schema");
+
+        input.requestHash = vm.parseJsonString(json, ".requestHash");
+        input.sourceCommit = vm.parseJsonString(json, ".sourceCommit");
+        input.chainId = _readUint(vm, json, ".chainId");
+        input.blockNumber = _readUint(vm, json, ".blockNumber");
+        input.blockHash = vm.parseJsonBytes32(json, ".blockHash");
+        input.deployer = vm.parseJsonAddress(json, ".deployer");
+        input.oracleRoutersGovernor = vm.parseJsonAddress(json, ".oracleRoutersGovernor");
+        input.vaultsGovernor = vm.parseJsonAddress(json, ".vaultsGovernor");
+        input.assets = vm.parseJsonAddressArray(json, ".assets");
+        input.vaults = vm.parseJsonAddressArray(json, ".vaults");
+        input.oracleRouters = vm.parseJsonAddressArray(json, ".oracleRouters");
+        input.irms = vm.parseJsonAddressArray(json, ".irms");
+        input.externalVaults = vm.parseJsonAddressArray(json, ".externalVaults");
+        input.stubOracle = vm.parseJsonAddress(json, ".stubOracle");
+        input.noStubOracle = vm.parseJsonBool(json, ".noStubOracle");
+        input.unitOfAccount = vm.parseJsonAddress(json, ".unitOfAccount");
+        input.feeReceiver = vm.parseJsonAddress(json, ".feeReceiver");
+        input.interestFee = _readUint16(vm, json, ".interestFee");
+        input.maxLiquidationDiscount = _readUint16(vm, json, ".maxLiquidationDiscount");
+        input.liquidationCoolOffTime = _readUint16(vm, json, ".liquidationCoolOffTime");
+        input.hookTarget = vm.parseJsonAddress(json, ".hookTarget");
+        input.hookedOps = _readUint32(vm, json, ".hookedOps");
+        input.configFlags = _readUint32(vm, json, ".configFlags");
+        input.forceZeroGovernors = vm.parseJsonBool(json, ".forceZeroGovernors");
+        input.rampDuration = _readUint32(vm, json, ".rampDuration");
+        input.spreadLTV = _readUint16(vm, json, ".spreadLTV");
+        input.oracleProviderBases = vm.parseJsonAddressArray(json, ".oracleProviderBases");
+        input.oracleProviders = vm.parseJsonStringArray(json, ".oracleProviders");
+        input.supplyCaps = _readUintArray(vm, json, ".supplyCaps");
+        input.borrowCaps = _readUintArray(vm, json, ".borrowCaps");
+        input.feeReceiverOverrides = vm.parseJsonAddressArray(json, ".feeReceiverOverrides");
+        input.interestFeeOverrides = _readUint16Array(vm, json, ".interestFeeOverrides");
+        input.maxLiquidationDiscountOverrides =
+            _readUint16Array(vm, json, ".maxLiquidationDiscountOverrides");
+        input.liquidationCoolOffTimeOverrides =
+            _readUint16Array(vm, json, ".liquidationCoolOffTimeOverrides");
+        input.hookTargetOverrides = vm.parseJsonAddressArray(json, ".hookTargetOverrides");
+        input.hookedOpsOverrides = _readUint32Array(vm, json, ".hookedOpsOverrides");
+        input.configFlagsOverrides = _readUint32Array(vm, json, ".configFlagsOverrides");
+
+        uint256 assetCount = input.assets.length;
+        input.kinkIRMParams = _readUint256x4Array(vm, json, ".kinkIRMParams", assetCount);
+        input.ltvs = _readUint16Matrix(vm, json, ".ltvs", assetCount, assetCount);
+        input.borrowLTVsOverride =
+            _readUint16Matrix(vm, json, ".borrowLTVsOverride", assetCount, assetCount);
+        input.spreadLTVOverride =
+            _readUint16Matrix(vm, json, ".spreadLTVOverride", assetCount, assetCount);
+        input.externalLTVs =
+            _readUint16Matrix(vm, json, ".externalLTVs", input.externalVaults.length, assetCount);
+        input.externalBorrowLTVsOverride = _readUint16Matrix(
+            vm, json, ".externalBorrowLTVsOverride", input.externalVaults.length, assetCount
+        );
+        input.externalSpreadLTVsOverride = _readUint16Matrix(
+            vm, json, ".externalSpreadLTVsOverride", input.externalVaults.length, assetCount
+        );
+
+        _validate(input);
+    }
+
+    function _validate(Input memory input) private pure {
+        uint256 assetCount = input.assets.length;
+        require(_isSha256Hash(input.requestHash), "DynamicClusterInput: request hash");
+        require(_isLowerHexCommit(input.sourceCommit), "DynamicClusterInput: source commit");
+        require(input.chainId != 0, "DynamicClusterInput: chain");
+        require(input.blockNumber != 0 && input.blockHash != bytes32(0), "DynamicClusterInput: block");
+        require(input.deployer != address(0), "DynamicClusterInput: deployer");
+        require(assetCount != 0, "DynamicClusterInput: assets");
+        _requireUniqueNonZero(input.assets, false, "DynamicClusterInput: duplicate asset");
+        require(input.vaults.length == assetCount, "DynamicClusterInput: vaults");
+        _requireUniqueNonZero(input.vaults, true, "DynamicClusterInput: duplicate vault");
+        require(input.oracleRouters.length == assetCount, "DynamicClusterInput: routers");
+        require(input.irms.length == assetCount, "DynamicClusterInput: irms");
+        _requireUniqueNonZero(input.externalVaults, false, "DynamicClusterInput: duplicate external vault");
+        for (uint256 i = 0; i < input.externalVaults.length; ++i) {
+            for (uint256 j = 0; j < input.vaults.length; ++j) {
+                require(input.externalVaults[i] != input.vaults[j], "DynamicClusterInput: overlapping vault");
+            }
+        }
+        require(input.unitOfAccount != address(0), "DynamicClusterInput: unit of account");
+        require(
+            input.forceZeroGovernors
+                || (input.oracleRoutersGovernor != address(0) && input.vaultsGovernor != address(0)),
+            "DynamicClusterInput: governors"
+        );
+        require(
+            input.oracleProviderBases.length == input.oracleProviders.length,
+            "DynamicClusterInput: oracle providers"
+        );
+        _requireUniqueNonZero(input.oracleProviderBases, false, "DynamicClusterInput: duplicate oracle base");
+        for (uint256 i = 0; i < input.oracleProviders.length; ++i) {
+            require(bytes(input.oracleProviders[i]).length != 0, "DynamicClusterInput: empty oracle provider");
+        }
+        require(input.supplyCaps.length == assetCount, "DynamicClusterInput: supply caps");
+        require(input.borrowCaps.length == assetCount, "DynamicClusterInput: borrow caps");
+        require(input.feeReceiverOverrides.length == assetCount, "DynamicClusterInput: fee overrides");
+        require(input.interestFeeOverrides.length == assetCount, "DynamicClusterInput: interest fee overrides");
+        require(
+            input.maxLiquidationDiscountOverrides.length == assetCount,
+            "DynamicClusterInput: liquidation discount overrides"
+        );
+        require(
+            input.liquidationCoolOffTimeOverrides.length == assetCount,
+            "DynamicClusterInput: cool off overrides"
+        );
+        require(input.hookTargetOverrides.length == assetCount, "DynamicClusterInput: hook overrides");
+        require(input.hookedOpsOverrides.length == assetCount, "DynamicClusterInput: hooked ops overrides");
+        require(input.configFlagsOverrides.length == assetCount, "DynamicClusterInput: config flag overrides");
+    }
+
+    function _isLowerHexCommit(string memory value) private pure returns (bool) {
+        bytes memory encoded = bytes(value);
+        if (encoded.length != 40) return false;
+        for (uint256 i = 0; i < encoded.length; ++i) {
+            bytes1 character = encoded[i];
+            if (!((character >= "0" && character <= "9") || (character >= "a" && character <= "f"))) return false;
+        }
+        return true;
+    }
+
+    function _isSha256Hash(string memory value) private pure returns (bool) {
+        bytes memory encoded = bytes(value);
+        bytes memory prefix = bytes("sha256:");
+        if (encoded.length != prefix.length + 64) return false;
+        for (uint256 i = 0; i < prefix.length; ++i) {
+            if (encoded[i] != prefix[i]) return false;
+        }
+        for (uint256 i = prefix.length; i < encoded.length; ++i) {
+            bytes1 character = encoded[i];
+            if (!((character >= "0" && character <= "9") || (character >= "a" && character <= "f"))) return false;
+        }
+        return true;
+    }
+
+    function _requireUniqueNonZero(address[] memory values, bool allowZero, string memory error) private pure {
+        for (uint256 i = 0; i < values.length; ++i) {
+            require(allowZero || values[i] != address(0), error);
+            if (values[i] == address(0)) continue;
+            for (uint256 j = i + 1; j < values.length; ++j) {
+                require(values[i] != values[j], error);
+            }
+        }
+    }
+
+    function _readUint(Vm vm, string memory json, string memory key) private pure returns (uint256) {
+        return vm.parseUint(vm.parseJsonString(json, key));
+    }
+
+    function _readUint16(Vm vm, string memory json, string memory key) private pure returns (uint16 result) {
+        uint256 value = _readUint(vm, json, key);
+        require(value <= type(uint16).max, "DynamicClusterInput: uint16 overflow");
+        result = uint16(value);
+    }
+
+    function _readUint32(Vm vm, string memory json, string memory key) private pure returns (uint32 result) {
+        uint256 value = _readUint(vm, json, key);
+        require(value <= type(uint32).max, "DynamicClusterInput: uint32 overflow");
+        result = uint32(value);
+    }
+
+    function _readUintArray(Vm vm, string memory json, string memory key)
+        private
+        pure
+        returns (uint256[] memory values)
+    {
+        string[] memory encoded = vm.parseJsonStringArray(json, key);
+        values = new uint256[](encoded.length);
+        for (uint256 i = 0; i < encoded.length; ++i) values[i] = vm.parseUint(encoded[i]);
+    }
+
+    function _readUint16Array(Vm vm, string memory json, string memory key)
+        private
+        pure
+        returns (uint16[] memory values)
+    {
+        uint256[] memory wide = _readUintArray(vm, json, key);
+        values = new uint16[](wide.length);
+        for (uint256 i = 0; i < wide.length; ++i) {
+            require(wide[i] <= type(uint16).max, "DynamicClusterInput: uint16 array overflow");
+            values[i] = uint16(wide[i]);
+        }
+    }
+
+    function _readUint32Array(Vm vm, string memory json, string memory key)
+        private
+        pure
+        returns (uint32[] memory values)
+    {
+        uint256[] memory wide = _readUintArray(vm, json, key);
+        values = new uint32[](wide.length);
+        for (uint256 i = 0; i < wide.length; ++i) {
+            require(wide[i] <= type(uint32).max, "DynamicClusterInput: uint32 array overflow");
+            values[i] = uint32(wide[i]);
+        }
+    }
+
+    function _readUint256x4Array(Vm vm, string memory json, string memory key, uint256 rows)
+        private
+        pure
+        returns (uint256[4][] memory values)
+    {
+        values = new uint256[4][](rows);
+        for (uint256 i = 0; i < rows; ++i) {
+            uint256[] memory row = _readUintArray(vm, json, string.concat(key, "[", vm.toString(i), "]"));
+            require(row.length == 4, "DynamicClusterInput: IRM row");
+            values[i] = [row[0], row[1], row[2], row[3]];
+        }
+    }
+
+    function _readUint16Matrix(
+        Vm vm,
+        string memory json,
+        string memory key,
+        uint256 rows,
+        uint256 columns
+    ) private pure returns (uint16[][] memory values) {
+        values = new uint16[][](rows);
+        for (uint256 i = 0; i < rows; ++i) {
+            values[i] = _readUint16Array(vm, json, string.concat(key, "[", vm.toString(i), "]"));
+            require(values[i].length == columns, "DynamicClusterInput: matrix row");
+        }
+    }
+}

--- a/script/production/market-ops/README.md
+++ b/script/production/market-ops/README.md
@@ -1,0 +1,77 @@
+# Dynamic Market Ops Cluster
+
+`DynamicCluster.s.sol` exposes the existing `ManageClusterBase` behavior through
+a request-scoped JSON input. It is intended as the EVK-owned planning and
+simulation entrypoint used by a controlled Market Ops provider.
+
+The entrypoint does not accept calldata from Toolbox. It accepts full desired
+cluster state, then lets EVK derive deployments, current-state deltas, critical
+sections, EVC batches, and direct, Safe, timelock, risk-steward, or emergency
+routing.
+
+## Input
+
+Set:
+
+- `MARKET_OPS_CLUSTER_INPUT` to an absolute input JSON path;
+- `MARKET_OPS_DEPLOYER` to the approved bootstrap actor;
+- `MARKET_OPS_FORK_BLOCK_NUMBER` to the exact block bound by the input;
+- `SCRIPT_OUTPUT_DIR` to an existing, request-scoped output directory;
+- `DEPLOYMENT_RPC_URL` and `ADDRESSES_DIR_PATH` as for other production scripts.
+
+All integer fields are decimal strings. This avoids JavaScript precision loss
+in provider implementations. Address-aligned arrays preserve the EVK asset and
+LTV matrix ordering. The input binds the parent Toolbox request hash, EVK source
+commit, chain, exact block, intended deployer, and whether EVK may deploy a
+temporary stub oracle.
+
+`example-input.json` documents the complete v1 shape. The example is parser
+evidence only and is not a deployable market default.
+
+## Output
+
+When `SCRIPT_OUTPUT_DIR` is set, EVK writes request-scoped copies of:
+
+- `Batches.json`;
+- `SafeTransaction_*.json` and `SafeBatchBuilder_*.json` when applicable;
+- `TimelockCalls.json` when applicable;
+- `Cluster.json`; and
+- `MarketOpsManifest.json`, which binds the input bytes, Toolbox request, and
+  exact `Batches.json` and `Cluster.json` bytes.
+
+`ClusterAddresses.json` is reserved for a separately approved broadcast flow;
+the non-broadcast provider runner never writes it.
+
+Existing scripts keep writing to `script/` when `SCRIPT_OUTPUT_DIR` is absent.
+
+This entrypoint is the EVK execution-semantic core, not the HTTP provider. The
+provider must still isolate jobs, pin the fork block, validate the canonical
+Toolbox request, map it to this complete desired state, and translate EVK output
+into the versioned Toolbox plan and simulation response.
+
+## Provider runner
+
+`plan.sh` is the fail-closed, non-broadcast process boundary for a controlled
+provider. It verifies the input's EVK commit and exact RPC block hash, rejects
+dirty tracked source and reused output directories, strips Foundry signing
+keys, and never passes `--broadcast`. Caller input and output paths may live
+outside the EVK checkout: the runner stages an exact input copy inside an
+ignored, Foundry-readable request workspace and exports artifacts only after
+validating the manifest. Foundry's dry-run transaction and runtime cache paths
+are isolated in the same workspace. The request workspace is removed on exit.
+
+`MARKET_OPS_DEPLOYER` supplies the simulated sender to the parent cluster and
+the existing nested EVK deployer scripts when no private key is present. It
+does not grant signing authority. The runner rejects dirty source, removes
+`DEPLOYER_KEY`, and invokes Foundry without `--broadcast`.
+
+Safe-backed routes require an explicit nonce, including an explicit zero. This
+prevents EVK's interactive nonce-discovery fallback from reaching the Safe API
+inside a deterministic provider job.
+
+The runner accepts route configuration separately from the Toolbox request.
+That distinction is intentional: Toolbox supplies reviewed desired semantics,
+while the controlled provider derives and configures the applicable deployer,
+Safe, timelock, risk-steward, or emergency route from authority evidence. The
+selected route is validated by `DynamicCluster` and included in
+`MarketOpsManifest.json`.

--- a/script/production/market-ops/example-input.json
+++ b/script/production/market-ops/example-input.json
@@ -1,0 +1,96 @@
+{
+  "schema": "evk-market-ops-cluster-input-v1",
+  "requestHash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "sourceCommit": "bae8aff5f35b41a9fd286aac0f2d89dc37acdb73",
+  "chainId": "1",
+  "blockNumber": "1",
+  "blockHash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+  "deployer": "0x1000000000000000000000000000000000000001",
+  "oracleRoutersGovernor": "0x2000000000000000000000000000000000000002",
+  "vaultsGovernor": "0x2000000000000000000000000000000000000002",
+  "assets": [
+    "0x3000000000000000000000000000000000000003"
+  ],
+  "vaults": [
+    "0x0000000000000000000000000000000000000000"
+  ],
+  "oracleRouters": [
+    "0x0000000000000000000000000000000000000000"
+  ],
+  "irms": [
+    "0x0000000000000000000000000000000000000000"
+  ],
+  "externalVaults": [],
+  "stubOracle": "0x0000000000000000000000000000000000000000",
+  "noStubOracle": true,
+  "unitOfAccount": "0x0000000000000000000000000000000000000348",
+  "feeReceiver": "0x0000000000000000000000000000000000000000",
+  "interestFee": "1000",
+  "maxLiquidationDiscount": "1500",
+  "liquidationCoolOffTime": "1",
+  "hookTarget": "0x0000000000000000000000000000000000000000",
+  "hookedOps": "0",
+  "configFlags": "0",
+  "forceZeroGovernors": false,
+  "rampDuration": "1209600",
+  "spreadLTV": "200",
+  "oracleProviderBases": [
+    "0x3000000000000000000000000000000000000003"
+  ],
+  "oracleProviders": [
+    "0x4000000000000000000000000000000000000004"
+  ],
+  "supplyCaps": [
+    "0"
+  ],
+  "borrowCaps": [
+    "0"
+  ],
+  "feeReceiverOverrides": [
+    "0x0000000000000000000000000000000000000000"
+  ],
+  "interestFeeOverrides": [
+    "1000"
+  ],
+  "maxLiquidationDiscountOverrides": [
+    "1500"
+  ],
+  "liquidationCoolOffTimeOverrides": [
+    "1"
+  ],
+  "hookTargetOverrides": [
+    "0x0000000000000000000000000000000000000000"
+  ],
+  "hookedOpsOverrides": [
+    "0"
+  ],
+  "configFlagsOverrides": [
+    "0"
+  ],
+  "kinkIRMParams": [
+    [
+      "0",
+      "0",
+      "0",
+      "0"
+    ]
+  ],
+  "ltvs": [
+    [
+      "0"
+    ]
+  ],
+  "borrowLTVsOverride": [
+    [
+      "65535"
+    ]
+  ],
+  "spreadLTVOverride": [
+    [
+      "65535"
+    ]
+  ],
+  "externalLTVs": [],
+  "externalBorrowLTVsOverride": [],
+  "externalSpreadLTVsOverride": []
+}

--- a/script/production/market-ops/plan.sh
+++ b/script/production/market-ops/plan.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    printf '%s\n' \
+        'Usage:' \
+        '  plan.sh --input FILE --output DIR --rpc-url URL --addresses-dir DIR' \
+        '    --route-kind KIND [route options]' \
+        '' \
+        'Required:' \
+        '  --input FILE             DynamicCluster JSON input.' \
+        '  --output DIR             New or empty request-scoped artifact directory.' \
+        '  --rpc-url URL            RPC endpoint used only for exact-state simulation.' \
+        '  --addresses-dir DIR      Euler interfaces addresses root.' \
+        '  --route-kind KIND        deployer-direct, direct, safe, safe-timelock,' \
+        '                           timelock, risk-steward, or emergency.' \
+        '' \
+        'Route options:' \
+        '  --safe-address ADDRESS' \
+        '  --safe-nonce NONCE' \
+        '  --timelock-address ADDRESS' \
+        '  --risk-steward-address ADDRESS' \
+        '  --emergency-kind ltv-collateral|ltv-borrowing|caps|operations' \
+        '  --emergency-vault ADDRESS|all' \
+        '  --skip-safe-simulation' \
+        '' \
+        'This command never signs or broadcasts. Route values are controlled-provider' \
+        'configuration, not browser-supplied Market Ops intent.'
+}
+
+fail() {
+    printf 'market-ops planner: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+absolute_file() {
+    local path=$1
+    local directory
+    directory=$(cd "$(dirname "$path")" && pwd -P)
+    printf '%s/%s\n' "$directory" "$(basename "$path")"
+}
+
+input_path=""
+output_dir=""
+rpc_url=""
+addresses_dir=""
+route_kind=""
+safe_address=""
+safe_nonce=""
+timelock_address=""
+risk_steward_address=""
+emergency_kind=""
+emergency_vault=""
+skip_safe_simulation=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --input|--output|--rpc-url|--addresses-dir|--route-kind|--safe-address|--safe-nonce|--timelock-address|--risk-steward-address|--emergency-kind|--emergency-vault)
+            [[ $# -ge 2 ]] || fail "missing value for $1"
+            case "$1" in
+                --input) input_path=$2 ;;
+                --output) output_dir=$2 ;;
+                --rpc-url) rpc_url=$2 ;;
+                --addresses-dir) addresses_dir=$2 ;;
+                --route-kind) route_kind=$2 ;;
+                --safe-address) safe_address=$2 ;;
+                --safe-nonce) safe_nonce=$2 ;;
+                --timelock-address) timelock_address=$2 ;;
+                --risk-steward-address) risk_steward_address=$2 ;;
+                --emergency-kind) emergency_kind=$2 ;;
+                --emergency-vault) emergency_vault=$2 ;;
+            esac
+            shift 2
+            ;;
+        --skip-safe-simulation)
+            skip_safe_simulation="--skip-safe-simulation"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unsupported option: $1"
+            ;;
+    esac
+done
+
+[[ -n "$input_path" ]] || fail "--input is required"
+[[ -n "$output_dir" ]] || fail "--output is required"
+[[ -n "$rpc_url" ]] || fail "--rpc-url is required"
+[[ -n "$addresses_dir" ]] || fail "--addresses-dir is required"
+[[ -n "$route_kind" ]] || fail "--route-kind is required"
+
+require_command cast
+require_command cmp
+require_command forge
+require_command git
+require_command jq
+
+[[ -f "$input_path" ]] || fail "input file does not exist"
+[[ -d "$addresses_dir" ]] || fail "addresses directory does not exist"
+
+repo_root=$(git rev-parse --show-toplevel)
+input_path=$(absolute_file "$input_path")
+addresses_dir=$(cd "$addresses_dir" && pwd -P)
+if [[ -e "$output_dir" ]]; then
+    [[ -d "$output_dir" ]] || fail "output path is not a directory"
+    [[ -z "$(find "$output_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]] \
+        || fail "output directory must be empty"
+else
+    mkdir -p "$output_dir"
+fi
+output_dir=$(cd "$output_dir" && pwd -P)
+
+schema=$(jq -er '.schema' "$input_path")
+[[ "$schema" == "evk-market-ops-cluster-input-v1" ]] || fail "unsupported input schema"
+source_commit=$(jq -er '.sourceCommit' "$input_path")
+request_hash=$(jq -er '.requestHash' "$input_path")
+chain_id=$(jq -er '.chainId' "$input_path")
+block_number=$(jq -er '.blockNumber' "$input_path")
+block_hash=$(jq -er '.blockHash | ascii_downcase' "$input_path")
+deployer=$(jq -er '.deployer' "$input_path")
+
+[[ "$source_commit" =~ ^[0-9a-f]{40}$ ]] || fail "input source commit is invalid"
+[[ "$request_hash" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "input request hash is invalid"
+[[ "$chain_id" =~ ^[1-9][0-9]*$ ]] || fail "input chain ID is invalid"
+[[ "$block_number" =~ ^[1-9][0-9]*$ ]] || fail "input block number is invalid"
+[[ "$block_hash" =~ ^0x[0-9a-f]{64}$ ]] || fail "input block hash is invalid"
+[[ "$deployer" =~ ^0x[0-9a-fA-F]{40}$ ]] || fail "input deployer is invalid"
+input_size=$(wc -c < "$input_path")
+[[ "$input_size" -le 5242880 ]] || fail "input file exceeds 5 MiB"
+if [[ -n "$safe_nonce" ]]; then
+    [[ "$safe_nonce" =~ ^[0-9]+$ ]] || fail "safe nonce is invalid"
+fi
+
+head_commit=$(git -C "$repo_root" rev-parse HEAD)
+[[ "$source_commit" == "$head_commit" ]] || fail "input source commit does not match this EVK checkout"
+[[ -z "$(git -C "$repo_root" status --porcelain --untracked-files=all --ignore-submodules=dirty)" ]] \
+    || fail "EVK source worktree is dirty"
+
+rpc_chain_id=$(cast chain-id --rpc-url "$rpc_url")
+[[ "$rpc_chain_id" == "$chain_id" ]] || fail "RPC chain does not match input"
+block_hex=$(printf '0x%x' "$block_number")
+rpc_block=$(cast rpc --rpc-url "$rpc_url" eth_getBlockByNumber "$block_hex" false)
+rpc_block_hash=$(printf '%s' "$rpc_block" | jq -er '.hash | ascii_downcase')
+[[ "$rpc_block_hash" == "$block_hash" ]] || fail "RPC block hash does not match input"
+
+batch_via_safe=""
+emergency_ltv_collateral=""
+emergency_ltv_borrowing=""
+emergency_caps=""
+emergency_operations=""
+
+case "$route_kind" in
+    deployer-direct|direct)
+        [[ -z "$safe_address$timelock_address$risk_steward_address$emergency_kind$emergency_vault" ]] \
+            || fail "direct route contains incompatible route options"
+        ;;
+    safe)
+        [[ "$safe_address" =~ ^0x[0-9a-fA-F]{40}$ ]] || fail "safe route requires --safe-address"
+        [[ -n "$safe_nonce" ]] || fail "safe route requires --safe-nonce, including an explicit zero"
+        [[ -z "$timelock_address$risk_steward_address$emergency_kind$emergency_vault" ]] \
+            || fail "safe route contains incompatible route options"
+        batch_via_safe="--batch-via-safe"
+        ;;
+    safe-timelock)
+        [[ "$safe_address" =~ ^0x[0-9a-fA-F]{40}$ ]] || fail "safe timelock route requires --safe-address"
+        [[ -n "$safe_nonce" ]] || fail "safe timelock route requires --safe-nonce, including an explicit zero"
+        [[ "$timelock_address" =~ ^0x[0-9a-fA-F]{40}$ ]] || fail "safe timelock route requires --timelock-address"
+        [[ -z "$risk_steward_address$emergency_kind$emergency_vault" ]] \
+            || fail "safe timelock route contains incompatible route options"
+        batch_via_safe="--batch-via-safe"
+        ;;
+    timelock)
+        [[ "$timelock_address" =~ ^0x[0-9a-fA-F]{40}$ ]] || fail "timelock route requires --timelock-address"
+        [[ -z "$safe_address$risk_steward_address$emergency_kind$emergency_vault" ]] \
+            || fail "timelock route contains incompatible route options"
+        ;;
+    risk-steward)
+        [[ "$risk_steward_address" =~ ^0x[0-9a-fA-F]{40}$ ]] \
+            || fail "risk steward route requires --risk-steward-address"
+        [[ -z "$emergency_kind$emergency_vault" ]] \
+            || fail "risk steward route contains emergency options"
+        if [[ -n "$safe_address" ]]; then
+            [[ "$safe_address" =~ ^0x[0-9a-fA-F]{40}$ ]] || fail "safe address is invalid"
+            [[ -n "$safe_nonce" ]] || fail "Safe-backed risk steward route requires --safe-nonce"
+            batch_via_safe="--batch-via-safe"
+        fi
+        if [[ -n "$timelock_address" ]]; then
+            [[ "$timelock_address" =~ ^0x[0-9a-fA-F]{40}$ ]] || fail "timelock address is invalid"
+        fi
+        ;;
+    emergency)
+        [[ "$emergency_vault" == "all" || "$emergency_vault" =~ ^0x[0-9a-fA-F]{40}$ ]] \
+            || fail "emergency route requires --emergency-vault ADDRESS|all"
+        case "$emergency_kind" in
+            ltv-collateral) emergency_ltv_collateral="--emergency-ltv-collateral" ;;
+            ltv-borrowing) emergency_ltv_borrowing="--emergency-ltv-borrowing" ;;
+            caps) emergency_caps="--emergency-caps" ;;
+            operations) emergency_operations="--emergency-operations" ;;
+            *) fail "emergency route requires a supported --emergency-kind" ;;
+        esac
+        [[ -z "$timelock_address$risk_steward_address" ]] \
+            || fail "emergency route contains incompatible route options"
+        if [[ -n "$safe_address" ]]; then
+            [[ "$safe_address" =~ ^0x[0-9a-fA-F]{40}$ ]] || fail "safe address is invalid"
+            [[ -n "$safe_nonce" ]] || fail "Safe-backed emergency route requires --safe-nonce"
+            batch_via_safe="--batch-via-safe"
+        fi
+        ;;
+    *)
+        fail "unsupported route kind: $route_kind"
+        ;;
+esac
+
+safe_nonce=${safe_nonce:-0}
+safe_nonce_explicit=false
+if [[ -n "$safe_address" ]]; then
+    safe_nonce_explicit=true
+fi
+
+mkdir -p "$repo_root/out"
+provider_work_dir=$(mktemp -d "$repo_root/out/market-ops-planner.XXXXXX")
+cleanup() {
+    rm -rf "$provider_work_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+provider_input_path="$provider_work_dir/request.json"
+provider_output_dir="$provider_work_dir/artifacts"
+provider_cache_dir="$provider_work_dir/cache"
+provider_broadcast_dir="$provider_work_dir/broadcast"
+cp "$input_path" "$provider_input_path"
+cmp -s "$input_path" "$provider_input_path" || fail "failed to stage an exact input copy"
+mkdir "$provider_output_dir" "$provider_cache_dir" "$provider_broadcast_dir"
+if [[ -f "$repo_root/cache/solidity-files-cache.json" ]]; then
+    cp "$repo_root/cache/solidity-files-cache.json" "$provider_cache_dir/solidity-files-cache.json"
+fi
+
+cd "$repo_root"
+env \
+    -u DEPLOYER_KEY \
+    -u SAFE_KEY \
+    ADDRESSES_DIR_PATH="$addresses_dir" \
+    DEPLOYMENT_RPC_URL="$rpc_url" \
+    FOUNDRY_BROADCAST="$provider_broadcast_dir" \
+    FOUNDRY_CACHE_PATH="$provider_cache_dir" \
+    MARKET_OPS_CLUSTER_INPUT="$provider_input_path" \
+    MARKET_OPS_DEPLOYER="$deployer" \
+    MARKET_OPS_FORK_BLOCK_NUMBER="$block_number" \
+    MARKET_OPS_ROUTE_KIND="$route_kind" \
+    MARKET_OPS_SAFE_NONCE_EXPLICIT="$safe_nonce_explicit" \
+    SCRIPT_OUTPUT_DIR="$provider_output_dir" \
+    batch_via_safe="$batch_via_safe" \
+    broadcast="" \
+    emergency_caps="$emergency_caps" \
+    emergency_ltv_borrowing="$emergency_ltv_borrowing" \
+    emergency_ltv_collateral="$emergency_ltv_collateral" \
+    emergency_operations="$emergency_operations" \
+    risk_steward_address="$risk_steward_address" \
+    safe_address="$safe_address" \
+    safe_nonce="$safe_nonce" \
+    skip_pending_simulation="--skip-pending-simulation" \
+    skip_safe_simulation="$skip_safe_simulation" \
+    timelock_address="$timelock_address" \
+    vault_address="$emergency_vault" \
+    forge script \
+        script/production/market-ops/DynamicCluster.s.sol:DynamicCluster \
+        --rpc-url "$rpc_url"
+
+provider_manifest="$provider_output_dir/MarketOpsManifest.json"
+[[ -f "$provider_output_dir/Batches.json" ]] || fail "EVK did not emit Batches.json"
+[[ -f "$provider_output_dir/Cluster.json" ]] || fail "EVK did not emit Cluster.json"
+[[ -f "$provider_manifest" ]] || fail "EVK did not emit MarketOpsManifest.json"
+[[ "$(jq -er '.broadcast' "$provider_manifest")" == "false" ]] \
+    || fail "manifest unexpectedly reports broadcast"
+[[ "$(jq -er '.requestHash' "$provider_manifest")" == "$request_hash" ]] \
+    || fail "manifest request hash mismatch"
+[[ "$(jq -er '.routeKind' "$provider_manifest")" == "$route_kind" ]] \
+    || fail "manifest route mismatch"
+jq -e '.batchesHash | test("^0x[0-9a-f]{64}$")' "$provider_manifest" >/dev/null \
+    || fail "manifest batches hash is invalid"
+jq -e '.clusterHash | test("^0x[0-9a-f]{64}$")' "$provider_manifest" >/dev/null \
+    || fail "manifest cluster hash is invalid"
+
+cp -R "$provider_output_dir"/. "$output_dir"/
+manifest="$output_dir/MarketOpsManifest.json"
+[[ -f "$manifest" ]] || fail "failed to export the validated planner artifacts"
+
+printf '%s\n' "$manifest"

--- a/script/utils/SafeUtils.s.sol
+++ b/script/utils/SafeUtils.s.sol
@@ -522,12 +522,12 @@ contract SafeTransaction is SafeUtil {
 
     function _dumpSafeTransaction(string memory fileName) private {
         console.log("Safe transaction payload saved to %s", fileName);
-        vm.writeJson(_getPayload(), string.concat(vm.projectRoot(), "/script/", fileName));
+        vm.writeJson(_getPayload(), getScriptOutputFilePath(fileName));
     }
 
     function _dumpBatchBuilderFile(string memory fileName) private {
         console.log("Safe Batch Builder file saved to %s", fileName);
-        vm.writeJson(_getBatchBuilderFile(), string.concat(vm.projectRoot(), "/script/", fileName));
+        vm.writeJson(_getBatchBuilderFile(), getScriptOutputFilePath(fileName));
     }
 }
 
@@ -634,7 +634,7 @@ contract SafeMultisendBuilder is SafeUtil {
 
     function _dumpMultisendBatchBuilderFile(address safe, string memory fileName) internal {
         console.log("Safe Batch Builder file saved to %s", fileName);
-        vm.writeJson(_getBatchBuilderFile(safe), string.concat(vm.projectRoot(), "/script/", fileName));
+        vm.writeJson(_getBatchBuilderFile(safe), getScriptOutputFilePath(fileName));
     }
 
     function _getBatchBuilderFile(address safe) private returns (string memory) {

--- a/script/utils/ScriptExtended.s.sol
+++ b/script/utils/ScriptExtended.s.sol
@@ -19,9 +19,14 @@ abstract contract ScriptExtended is Script {
         string memory deploymentRpcUrl = getDeploymentRpcUrl();
         if (bytes(deploymentRpcUrl).length != 0) {
             forks[DEFAULT_FORK_CHAIN_ID] = vm.activeFork();
+            uint256 marketOpsForkBlockNumber = vm.envOr("MARKET_OPS_FORK_BLOCK_NUMBER", uint256(0));
 
             if (forks[DEFAULT_FORK_CHAIN_ID] == 0) {
-                forks[DEFAULT_FORK_CHAIN_ID] = vm.createSelectFork(deploymentRpcUrl);
+                forks[DEFAULT_FORK_CHAIN_ID] = marketOpsForkBlockNumber == 0
+                    ? vm.createSelectFork(deploymentRpcUrl)
+                    : vm.createSelectFork(deploymentRpcUrl, marketOpsForkBlockNumber);
+            } else if (marketOpsForkBlockNumber != 0) {
+                require(block.number == marketOpsForkBlockNumber, "ScriptExtended: fork block mismatch");
             }
 
             forks[block.chainid] = forks[DEFAULT_FORK_CHAIN_ID];
@@ -51,8 +56,10 @@ abstract contract ScriptExtended is Script {
         }
     }
 
-    function getDeployer() internal view returns (address) {
-        return deployerAddress;
+    function getDeployer() internal view virtual returns (address) {
+        return deployerAddress == address(0)
+            ? vm.envOr("MARKET_OPS_DEPLOYER", address(0))
+            : deployerAddress;
     }
 
     function getSafeSigner() internal view returns (address) {
@@ -337,6 +344,23 @@ abstract contract ScriptExtended is Script {
     function getScriptFilePath(string memory jsonFile) internal view returns (string memory) {
         string memory root = vm.projectRoot();
         return string.concat(root, "/script/", jsonFile);
+    }
+
+    function getScriptOutputDirPath() internal view returns (string memory) {
+        return resolveScriptOutputDirPath(vm.envOr("SCRIPT_OUTPUT_DIR", string("")));
+    }
+
+    function resolveScriptOutputDirPath(string memory path) internal view returns (string memory) {
+        if (bytes(path).length == 0) return string.concat(vm.projectRoot(), "/script");
+
+        require(vm.isDir(path), "getScriptOutputDirPath: SCRIPT_OUTPUT_DIR does not exist");
+        return bytes(path)[bytes(path).length - 1] == "/"
+            ? _substring(path, 0, bytes(path).length - 1)
+            : path;
+    }
+
+    function getScriptOutputFilePath(string memory fileName) internal view returns (string memory) {
+        return string.concat(getScriptOutputDirPath(), "/", fileName);
     }
 
     function getScriptFile(string memory jsonFile) internal view returns (string memory) {

--- a/script/utils/ScriptUtils.s.sol
+++ b/script/utils/ScriptUtils.s.sol
@@ -513,7 +513,10 @@ abstract contract ScriptUtils is
 
         address safe = getSafe(false);
         safeNonce = getSafeNonce();
-        if (safe != address(0) && safeNonce == 0) {
+        if (
+            safe != address(0) && safeNonce == 0
+                && !vm.envOr("MARKET_OPS_SAFE_NONCE_EXPLICIT", false)
+        ) {
             SafeUtil util = new SafeUtil();
             safeNonce = util.getNextNonce(safe);
         }
@@ -1125,7 +1128,7 @@ abstract contract BatchBuilder is ScriptUtils {
     }
 
     function dumpBatch(address from) internal {
-        string memory path = string.concat(vm.projectRoot(), "/script/Batches.json");
+        string memory path = getScriptOutputFilePath("Batches.json");
         string memory json = vm.exists(path) ? vm.readFile(path) : "{}";
         string memory key = string.concat("batch", vm.toString(batchCounter));
 
@@ -1140,7 +1143,7 @@ abstract contract BatchBuilder is ScriptUtils {
     function dumpTimelockCall(uint256 i) internal {
         require(i < timelockCalls.length, "dumpTimelockCall: incorrect index");
 
-        string memory path = string.concat(vm.projectRoot(), "/script/TimelockCalls.json");
+        string memory path = getScriptOutputFilePath("TimelockCalls.json");
         string memory json = vm.exists(path) ? vm.readFile(path) : "{}";
         string memory key = vm.toString(timelockCalls[i].id);
 

--- a/test/MarketOps/DynamicClusterInput.t.sol
+++ b/test/MarketOps/DynamicClusterInput.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {DynamicClusterInputLib} from "../../script/production/market-ops/DynamicClusterInput.s.sol";
+
+contract DynamicClusterInputTest is Test {
+    function testReadsExactDynamicClusterInput() public view {
+        string memory path =
+            string.concat(vm.projectRoot(), "/script/production/market-ops/example-input.json");
+        (DynamicClusterInputLib.Input memory input, bytes32 inputHash) =
+            DynamicClusterInputLib.read(vm, path);
+
+        assertEq(input.schema, "evk-market-ops-cluster-input-v1");
+        assertEq(input.requestHash, "sha256:1111111111111111111111111111111111111111111111111111111111111111");
+        assertEq(input.chainId, 1);
+        assertEq(input.blockNumber, 1);
+        assertEq(input.deployer, 0x1000000000000000000000000000000000000001);
+        assertEq(input.assets.length, 1);
+        assertEq(input.vaults.length, 1);
+        assertEq(input.oracleRouters.length, 1);
+        assertEq(input.irms.length, 1);
+        assertEq(input.externalVaults.length, 0);
+        assertTrue(input.noStubOracle);
+        assertEq(input.oracleProviderBases.length, 1);
+        assertEq(input.oracleProviders.length, 1);
+        assertEq(input.supplyCaps[0], 0);
+        assertEq(input.borrowCaps[0], 0);
+        assertEq(input.interestFee, 1000);
+        assertEq(input.maxLiquidationDiscount, 1500);
+        assertEq(input.liquidationCoolOffTime, 1);
+        assertEq(input.rampDuration, 14 days);
+        assertEq(input.spreadLTV, 200);
+        assertEq(input.kinkIRMParams.length, 1);
+        assertEq(input.ltvs.length, 1);
+        assertEq(input.ltvs[0].length, 1);
+        assertEq(input.borrowLTVsOverride[0][0], type(uint16).max);
+        assertEq(input.spreadLTVOverride[0][0], type(uint16).max);
+        assertTrue(inputHash != bytes32(0));
+    }
+}

--- a/test/MarketOps/DynamicClusterRoute.t.sol
+++ b/test/MarketOps/DynamicClusterRoute.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {DynamicCluster} from "../../script/production/market-ops/DynamicCluster.s.sol";
+
+contract DynamicClusterRouteHarness is DynamicCluster {
+    function validate(
+        string memory kind,
+        bool viaSafe,
+        address safe,
+        address timelock,
+        address riskSteward,
+        bool emergency
+    ) external pure {
+        validateRouteConfig(kind, viaSafe, safe, timelock, riskSteward, emergency);
+    }
+}
+
+contract DynamicClusterRouteTest is Test {
+    DynamicClusterRouteHarness private harness;
+
+    function setUp() public {
+        harness = new DynamicClusterRouteHarness();
+    }
+
+    function testAcceptsExplicitRouteEvidence() public view {
+        harness.validate("deployer-direct", false, address(0), address(0), address(0), false);
+        harness.validate("safe", true, address(1), address(0), address(0), false);
+        harness.validate("safe-timelock", true, address(1), address(2), address(0), false);
+        harness.validate("timelock", false, address(0), address(2), address(0), false);
+        harness.validate("risk-steward", true, address(1), address(0), address(3), false);
+        harness.validate("emergency", true, address(1), address(0), address(0), true);
+    }
+
+    function testRejectsRouteClaimWithoutRequiredEvidence() public {
+        vm.expectRevert("DynamicCluster: safe route");
+        harness.validate("safe", false, address(0), address(0), address(0), false);
+
+        vm.expectRevert("DynamicCluster: safe timelock route");
+        harness.validate("safe-timelock", true, address(1), address(0), address(0), false);
+
+        vm.expectRevert("DynamicCluster: risk steward route");
+        harness.validate("risk-steward", false, address(0), address(0), address(0), false);
+
+        vm.expectRevert("DynamicCluster: emergency route");
+        harness.validate("emergency", true, address(1), address(0), address(0), false);
+    }
+
+    function testRejectsUnsupportedRoute() public {
+        vm.expectRevert("DynamicCluster: unsupported route");
+        harness.validate("browser-selected", false, address(0), address(0), address(0), false);
+    }
+}

--- a/test/MarketOps/ScriptOutputPath.t.sol
+++ b/test/MarketOps/ScriptOutputPath.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {ScriptExtended} from "../../script/utils/ScriptExtended.s.sol";
+
+contract ScriptOutputPathHarness is ScriptExtended {
+    function resolveOutputDir(string memory path) external view returns (string memory) {
+        return resolveScriptOutputDirPath(path);
+    }
+
+    function resolveOutputFile(string memory path, string memory fileName) external view returns (string memory) {
+        return string.concat(resolveScriptOutputDirPath(path), "/", fileName);
+    }
+}
+
+contract ScriptOutputPathTest is Test {
+    ScriptOutputPathHarness private harness;
+
+    function setUp() public {
+        harness = new ScriptOutputPathHarness();
+    }
+
+    function testDefaultsToScriptDirectory() public view {
+        assertEq(harness.resolveOutputDir(""), string.concat(vm.projectRoot(), "/script"));
+        assertEq(
+            harness.resolveOutputFile("", "Batches.json"), string.concat(vm.projectRoot(), "/script/Batches.json")
+        );
+    }
+
+    function testUsesRequestScopedDirectory() public view {
+        string memory outputDir = string.concat(vm.projectRoot(), "/test/MarketOps");
+
+        assertEq(harness.resolveOutputDir(string.concat(outputDir, "/")), outputDir);
+        assertEq(
+            harness.resolveOutputFile(string.concat(outputDir, "/"), "Batches.json"),
+            string.concat(outputDir, "/Batches.json")
+        );
+    }
+}

--- a/test/MarketOps/SimulatedDeployer.t.sol
+++ b/test/MarketOps/SimulatedDeployer.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {ScriptExtended} from "../../script/utils/ScriptExtended.s.sol";
+
+contract SimulatedDeployerHarness is ScriptExtended {
+    function deployer() external view returns (address) {
+        return getDeployer();
+    }
+}
+
+contract SimulatedDeployerTest is Test {
+    function testUsesRequestScopedDeployerWithoutPrivateKey() public {
+        address expected = 0x1000000000000000000000000000000000000001;
+        vm.setEnv("MARKET_OPS_DEPLOYER", vm.toString(expected));
+
+        SimulatedDeployerHarness harness = new SimulatedDeployerHarness();
+
+        assertEq(harness.deployer(), expected);
+    }
+}


### PR DESCRIPTION
## Summary

Add a dynamic, request-scoped EVK planner boundary for Market Ops. It accepts a complete desired cluster state, projects it through the existing `ManageClusterBase` semantics, and emits deterministic non-broadcast artifacts at an exact chain block.

## Changes

- add a strict `evk-market-ops-cluster-input-v1` parser for dynamic assets, vaults, routers, IRMs, oracle providers, caps, and LTV matrices
- add a dynamic cluster entrypoint backed by existing EVK management semantics
- add explicit Safe, timelock, risk-steward, emergency, direct, and deployer-direct route validation
- emit request-scoped `Batches.json`, `Cluster.json`, and `MarketOpsManifest.json` artifacts
- bind the canonical input plus exact Batches and Cluster artifact hashes into the non-broadcast manifest
- add a fail-closed runner that pins source and block hashes, strips signing keys, never broadcasts, and isolates request input, output, and cache paths
- preserve existing script output behavior when request-scoped output variables are absent

This PR provides the EVK semantic core and local provider runner. It does not add a hosted HTTP service, signing, or transaction broadcasting.

## Tests

- `forge build`
- `forge test --match-path "test/MarketOps/*.t.sol" -vv` (7 passed)
- `shellcheck script/production/market-ops/plan.sh`
- `bash -n script/production/market-ops/plan.sh`
- `git diff --check`
- exact-block Ethereum dry run for a dynamic one-vault request; independently recomputed Batches and Cluster hashes matched the manifest, which reported `broadcast: false`