### PR TITLE
chore: stop deploying the emergency governor suite, cap risk steward and Edge contracts on new chains

### DIFF
--- a/script/50_CoreAndPeriphery.s.sol
+++ b/script/50_CoreAndPeriphery.s.sol
@@ -21,26 +21,19 @@ import {
 import {
     EVKFactoryPerspectiveDeployer,
     EVKPerspectiveEscrowedCollateralDeployer,
-    EulerEarnFactoryPerspectiveDeployer,
-    EdgePerspectivesDeployer
+    EulerEarnFactoryPerspectiveDeployer
 } from "./09_Perspectives.s.sol";
 import {Swap} from "./10_Swap.s.sol";
 import {FeeFlow} from "./11_FeeFlow.s.sol";
 import {EVaultFactoryGovernorDeployer, TimelockControllerDeployer} from "./12_Governor.s.sol";
 import {TermsOfUseSignerDeployer} from "./13_TermsOfUseSigner.s.sol";
 import {OFTAdapterUpgradeableDeployer, MintBurnOFTAdapterDeployer} from "./14_OFT.s.sol";
-import {EdgeFactoryDeployer} from "./15_EdgeFactory.s.sol";
 import {EulerEarnFactoryDeployer} from "./20_EulerEarnFactory.s.sol";
 import {EulerSwapImplementationDeployer} from "./21_EulerSwapImplementation.s.sol";
 import {EulerSwapFactoryDeployer} from "./22_EulerSwapFactory.s.sol";
 import {EulerSwapPeripheryDeployer} from "./23_EulerSwapPeriphery.s.sol";
 import {EulerSwapRegistryDeployer} from "./24_EulerSwapRegistry.s.sol";
 import {FactoryGovernor} from "./../src/Governor/FactoryGovernor.sol";
-import {
-    IGovernorAccessControlEmergencyFactory,
-    GovernorAccessControlEmergencyFactory
-} from "./../src/GovernorFactory/GovernorAccessControlEmergencyFactory.sol";
-import {CapRiskStewardFactory} from "./../src/GovernorFactory/CapRiskStewardFactory.sol";
 import {ERC20BurnableMintable} from "./../src/ERC20/deployed/ERC20BurnableMintable.sol";
 import {RewardToken} from "./../src/ERC20/deployed/RewardToken.sol";
 import {FeeCollectorUtil} from "./../src/Util/FeeCollectorUtil.sol";
@@ -96,8 +89,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
     uint256 internal constant HUB_CHAIN_ID = 1;
     uint8 internal constant STANDARD_DECIMALS = 18;
     uint256 internal constant EVAULT_FACTORY_TIMELOCK_MIN_DELAY = 4 days;
-    uint256 internal constant ACCESS_CONTROL_EMERGENCY_GOVERNOR_ADMIN_TIMELOCK_MIN_DELAY = 2 days;
-    uint256 internal constant ACCESS_CONTROL_EMERGENCY_GOVERNOR_WILDCARD_TIMELOCK_MIN_DELAY = 2 days;
     uint256 internal constant EUSD_ADMIN_TIMELOCK_MIN_DELAY = 7 days;
     address[2] internal EVAULT_FACTORY_GOVERNOR_PAUSERS =
         [0xff217004BdD3A6A592162380dc0E6BbF143291eB, 0xcC6451385685721778E7Bd80B54F8c92b484F601];
@@ -674,79 +665,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
             console.log("- FeeFlowController already deployed. Skipping...");
         }
 
-        if (
-            governorAddresses.accessControlEmergencyGovernorAdminTimelockController == address(0)
-                && governorAddresses.accessControlEmergencyGovernorWildcardTimelockController == address(0)
-                && governorAddresses.accessControlEmergencyGovernor == address(0)
-                && governorAddresses.capRiskSteward == address(0)
-        ) {
-            console.log("+ Deploying GovernorAccessControlEmergency contracts suite...");
-
-            IGovernorAccessControlEmergencyFactory.TimelockControllerParams memory adminTimelockControllerParams;
-            IGovernorAccessControlEmergencyFactory.TimelockControllerParams memory wildcardTimelockControllerParams;
-            address[] memory governorAccessControlEmergencyGuardians;
-
-            adminTimelockControllerParams.minDelay = ACCESS_CONTROL_EMERGENCY_GOVERNOR_ADMIN_TIMELOCK_MIN_DELAY;
-            adminTimelockControllerParams.proposers = new address[](1);
-            adminTimelockControllerParams.proposers[0] = multisigAddresses.DAO;
-            adminTimelockControllerParams.cancellers = new address[](2);
-            adminTimelockControllerParams.cancellers[0] = multisigAddresses.DAO;
-            adminTimelockControllerParams.cancellers[1] = multisigAddresses.labs;
-            adminTimelockControllerParams.executors = new address[](1);
-            adminTimelockControllerParams.executors[0] = address(0);
-
-            console.log("    Granting admin timelock controller proposer role to address %s", multisigAddresses.DAO);
-            console.log("    Granting admin timelock controller canceller role to address %s", multisigAddresses.DAO);
-            console.log("    Granting admin timelock controller canceller role to address %s", multisigAddresses.labs);
-            console.log("    Granting admin timelock controller executor role to anyone");
-
-            wildcardTimelockControllerParams.minDelay = ACCESS_CONTROL_EMERGENCY_GOVERNOR_WILDCARD_TIMELOCK_MIN_DELAY;
-            wildcardTimelockControllerParams.proposers = new address[](1);
-            wildcardTimelockControllerParams.proposers[0] = multisigAddresses.DAO;
-            wildcardTimelockControllerParams.cancellers = new address[](2);
-            wildcardTimelockControllerParams.cancellers[0] = multisigAddresses.DAO;
-            wildcardTimelockControllerParams.cancellers[1] = multisigAddresses.labs;
-            wildcardTimelockControllerParams.executors = new address[](1);
-            wildcardTimelockControllerParams.executors[0] = address(0);
-
-            console.log("    Granting wildcard timelock controller proposer role to address %s", multisigAddresses.DAO);
-            console.log("    Granting wildcard timelock controller canceller role to address %s", multisigAddresses.DAO);
-            console.log(
-                "    Granting wildcard timelock controller canceller role to address %s", multisigAddresses.labs
-            );
-            console.log("    Granting wildcard timelock controller executor role to anyone");
-
-            governorAccessControlEmergencyGuardians = new address[](1);
-            governorAccessControlEmergencyGuardians[0] = multisigAddresses.labs;
-
-            console.log(
-                "    Granting emergency access control governor guardian role to address %s", multisigAddresses.labs
-            );
-
-            startBroadcast();
-            (
-                governorAddresses.accessControlEmergencyGovernorAdminTimelockController,
-                governorAddresses.accessControlEmergencyGovernorWildcardTimelockController,
-                governorAddresses.accessControlEmergencyGovernor
-            ) =
-                GovernorAccessControlEmergencyFactory(peripheryAddresses.governorAccessControlEmergencyFactory)
-                    .deploy(
-                        adminTimelockControllerParams,
-                        wildcardTimelockControllerParams,
-                        governorAccessControlEmergencyGuardians
-                    );
-
-            //governorAddresses.capRiskSteward = CapRiskStewardFactory(peripheryAddresses.capRiskStewardFactory).deploy(
-            //    governorAddresses.accessControlEmergencyGovernor,
-            //    peripheryAddresses.kinkIRMFactory,
-            //    multisigAddresses.DAO
-            //);
-
-            stopBroadcast();
-        } else {
-            console.log("- GovernorAccessControlEmergency contracts suite already deployed. Skipping...");
-        }
-
         if (peripheryAddresses.swapper == address(0) && peripheryAddresses.swapVerifier == address(0)) {
             console.log("+ Deploying Swapper...");
             Swap deployer = new Swap();
@@ -796,26 +714,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
             }
         } else {
             console.log("- EulerEarnFactoryPerspective already deployed. Skipping...");
-        }
-
-        if (peripheryAddresses.edgeFactory == address(0)) {
-            console.log("+ Deploying EdgeFactory...");
-            EdgeFactoryDeployer deployer = new EdgeFactoryDeployer();
-            peripheryAddresses.edgeFactory = deployer.deploy(
-                coreAddresses.eVaultFactory,
-                peripheryAddresses.oracleRouterFactory,
-                peripheryAddresses.escrowedCollateralPerspective
-            );
-        } else {
-            console.log("- EdgeFactory already deployed. Skipping...");
-        }
-
-        if (peripheryAddresses.edgeFactoryPerspective == address(0)) {
-            console.log("+ Deploying EdgeFactoryPerspective...");
-            EdgePerspectivesDeployer deployer = new EdgePerspectivesDeployer();
-            peripheryAddresses.edgeFactoryPerspective = deployer.deploy(peripheryAddresses.edgeFactory)[0];
-        } else {
-            console.log("- EdgeFactoryPerspective already deployed. Skipping...");
         }
 
         if (peripheryAddresses.securitizeFactory == address(0)) {

--- a/script/50_CoreAndPeriphery.s.sol
+++ b/script/50_CoreAndPeriphery.s.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import {BatchBuilder, Vm, console} from "./utils/ScriptUtils.s.sol";
 import {SafeMultisendBuilder, SafeTransaction} from "./utils/SafeUtils.s.sol";
 import {LayerZeroUtil} from "./utils/LayerZeroUtils.s.sol";
-import {ERC20BurnableMintableDeployer, RewardTokenDeployer, ERC20SynthDeployer, ERC20Synth} from "./00_ERC20.s.sol";
+import {ERC20BurnableMintableDeployer, RewardTokenDeployer} from "./00_ERC20.s.sol";
 import {Integrations, ProtocolConfig} from "./01_Integrations.s.sol";
 import {PeripheryFactories} from "./02_PeripheryFactories.s.sol";
 import {EVaultImplementation} from "./05_EVaultImplementation.s.sol";
@@ -36,10 +36,6 @@ import {EulerSwapRegistryDeployer} from "./24_EulerSwapRegistry.s.sol";
 import {FactoryGovernor} from "./../src/Governor/FactoryGovernor.sol";
 import {ERC20BurnableMintable} from "./../src/ERC20/deployed/ERC20BurnableMintable.sol";
 import {RewardToken} from "./../src/ERC20/deployed/RewardToken.sol";
-import {FeeCollectorUtil} from "./../src/Util/FeeCollectorUtil.sol";
-import {OFTFeeCollectorGulper} from "./../src/OFT/OFTFeeCollectorGulper.sol";
-import {OFTFeeCollector} from "./../src/OFT/OFTFeeCollector.sol";
-import {EulerSavingsRate} from "evk/Synths/EulerSavingsRate.sol";
 import {Base} from "evk/EVault/shared/Base.sol";
 import {ProtocolConfig} from "evk/ProtocolConfig/ProtocolConfig.sol";
 import {AccessControl} from "openzeppelin-contracts/access/AccessControl.sol";
@@ -77,8 +73,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
         bool deployEULOFT;
         bool deployEulerEarn;
         bool deployEulerSwap;
-        bool deployEUSD;
-        bool deploySEUSD;
         bool deploySecuritizeFactory;
         address uniswapPoolManager;
         address eulerSwapProtocolFeeConfigAdmin;
@@ -89,7 +83,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
     uint256 internal constant HUB_CHAIN_ID = 1;
     uint8 internal constant STANDARD_DECIMALS = 18;
     uint256 internal constant EVAULT_FACTORY_TIMELOCK_MIN_DELAY = 4 days;
-    uint256 internal constant EUSD_ADMIN_TIMELOCK_MIN_DELAY = 7 days;
     address[2] internal EVAULT_FACTORY_GOVERNOR_PAUSERS =
         [0xff217004BdD3A6A592162380dc0E6BbF143291eB, 0xcC6451385685721778E7Bd80B54F8c92b484F601];
 
@@ -123,22 +116,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
             cfg.configIgnoreChainIds = [uint256(2818), 999, 1923];
             cfg.configOneDirectionChainIds = [uint256(130), 143, 146, 239, 9745, 43114, 59144, 60808, 80094];
         }
-
-        {
-            OFTTokenConfig storage cfg = OFT_CONFIG["eUSD"];
-            cfg.enforcedGasLimitSend = 150000;
-            cfg.enforcedGasLimitCall = 100000;
-            cfg.requiredDVNsCount = 4;
-            cfg.configIgnoreChainIds = [uint256(2818), 999];
-        }
-
-        {
-            OFTTokenConfig storage cfg = OFT_CONFIG["seUSD"];
-            cfg.enforcedGasLimitSend = 100000;
-            cfg.enforcedGasLimitCall = 100000;
-            cfg.requiredDVNsCount = 4;
-            cfg.configIgnoreChainIds = [uint256(2818), 999];
-        }
     }
 
     function run()
@@ -165,8 +142,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
             deployEULOFT: vm.parseJsonBool(json, ".deployEULOFT"),
             deployEulerEarn: vm.parseJsonBool(json, ".deployEulerEarn"),
             deployEulerSwap: vm.parseJsonBool(json, ".deployEulerSwap"),
-            deployEUSD: vm.parseJsonBool(json, ".deployEUSD"),
-            deploySEUSD: vm.parseJsonBool(json, ".deploySEUSD"),
             deploySecuritizeFactory: vm.parseJsonBool(json, ".deploySecuritizeFactory"),
             uniswapPoolManager: vm.parseJsonAddress(json, ".uniswapPoolManager"),
             eulerSwapProtocolFeeConfigAdmin: vm.parseJsonAddress(json, ".eulerSwapProtocolFeeConfigAdmin"),
@@ -344,196 +319,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
             configureOFTAdapter(tokenAddresses.EUL, bridgeAddresses.eulOFTAdapter);
         }
 
-        if (tokenAddresses.eUSD == address(0)) {
-            if (input.deployEUSD) {
-                console.log("+ Deploying eUSD...");
-                {
-                    ERC20SynthDeployer deployer = new ERC20SynthDeployer();
-                    tokenAddresses.eUSD = deployer.deploy(coreAddresses.evc, "Euler USD", "eUSD", STANDARD_DECIMALS);
-                }
-
-                startBroadcast();
-                console.log("    Granting eUSD revoke minter role to the desired address %s", multisigAddresses.labs);
-                bytes32 revokeMinterRole = ERC20BurnableMintable(tokenAddresses.eUSD).REVOKE_MINTER_ROLE();
-                AccessControl(tokenAddresses.eUSD).grantRole(revokeMinterRole, multisigAddresses.labs);
-                stopBroadcast();
-
-                console.log(" + Deploying eUSD timelock controller...");
-                {
-                    TimelockControllerDeployer deployer = new TimelockControllerDeployer();
-                    address[] memory proposers = new address[](1);
-                    address[] memory executors = new address[](1);
-                    proposers[0] = multisigAddresses.DAO;
-                    executors[0] = address(0);
-                    governorAddresses.eUSDAdminTimelockController =
-                        deployer.deploy(EUSD_ADMIN_TIMELOCK_MIN_DELAY, proposers, executors);
-                }
-
-                console.log("    Granting proposer role to address %s", multisigAddresses.DAO);
-                console.log("    Granting canceller role to address %s", multisigAddresses.DAO);
-                console.log("    Granting executor role to anyone");
-                console.log("    Granting canceller role to address %s", multisigAddresses.labs);
-
-                startBroadcast();
-                bytes32 cancellerRole =
-                    TimelockController(payable(governorAddresses.eUSDAdminTimelockController)).CANCELLER_ROLE();
-                AccessControl(governorAddresses.eUSDAdminTimelockController)
-                    .grantRole(cancellerRole, multisigAddresses.labs);
-
-                console.log(
-                    "    Granting eUSD allocator role to the desired address %s",
-                    governorAddresses.eUSDAdminTimelockController
-                );
-                bytes32 allocatorRole = ERC20Synth(tokenAddresses.eUSD).ALLOCATOR_ROLE();
-                AccessControl(tokenAddresses.eUSD)
-                    .grantRole(allocatorRole, governorAddresses.eUSDAdminTimelockController);
-                stopBroadcast();
-            } else {
-                console.log("! eUSD deployment deliberately skipped. Skipping...");
-            }
-        } else {
-            console.log("- eUSD already deployed. Skipping...");
-        }
-
-        if (bridgeAddresses.eusdOFTAdapter == address(0)) {
-            if (tokenAddresses.eUSD != address(0)) {
-                console.log("+ Deploying OFT Adapter for eUSD...");
-                bridgeAddresses.eusdOFTAdapter = deployOFTAdapter(tokenAddresses.eUSD, false);
-
-                bytes32 defaultAdminRole = ERC20BurnableMintable(tokenAddresses.eUSD).DEFAULT_ADMIN_ROLE();
-                if (ERC20BurnableMintable(tokenAddresses.eUSD).hasRole(defaultAdminRole, getDeployer())) {
-                    vm.startBroadcast();
-                    console.log(
-                        "    Setting eUSD minter capacity to for the OFT Adapter %s", bridgeAddresses.eusdOFTAdapter
-                    );
-                    ERC20Synth(tokenAddresses.eUSD).setCapacity(bridgeAddresses.eusdOFTAdapter, type(uint128).max);
-                    stopBroadcast();
-                } else if (ERC20BurnableMintable(tokenAddresses.eUSD).hasRole(defaultAdminRole, getSafe(false))) {
-                    console.log(
-                        "    Adding multisend item to set eUSD minter capacity to for the OFT Adapter %s",
-                        bridgeAddresses.eusdOFTAdapter
-                    );
-                    addMultisendItem(
-                        tokenAddresses.eUSD,
-                        abi.encodeCall(ERC20Synth.setCapacity, (bridgeAddresses.eusdOFTAdapter, type(uint128).max))
-                    );
-                } else {
-                    console.log(
-                        "    ! The deployer or designated safe no longer has the default admin role to set the eUSD minter capacity for the OFT Adapter. This must be done manually. Skipping..."
-                    );
-                }
-            } else {
-                console.log("! eUSD OFT Adapter deployment skipped. Skipping...");
-            }
-        } else {
-            console.log("- eUSD OFT Adapter already deployed. Skipping...");
-        }
-
-        if (
-            bridgeAddresses.eusdOFTAdapter != address(0)
-                && !containsOFTConfigIgnoreChainId(tokenAddresses.eUSD, block.chainid) && !getSkipOFTConfigEUSD()
-        ) {
-            console.log("+ Attempting to configure OFT Adapter on chain %s for EUSD", block.chainid);
-            configureOFTAdapter(tokenAddresses.eUSD, bridgeAddresses.eusdOFTAdapter);
-        }
-
-        if (tokenAddresses.seUSD == address(0)) {
-            if (input.deploySEUSD) {
-                console.log("+ Deploying seUSD...");
-                if (block.chainid == HUB_CHAIN_ID) {
-                    startBroadcast();
-                    tokenAddresses.seUSD = address(
-                        new EulerSavingsRate(coreAddresses.evc, tokenAddresses.eUSD, "Savings Rate eUSD", "seUSD")
-                    );
-                    stopBroadcast();
-                } else {
-                    ERC20BurnableMintableDeployer deployer = new ERC20BurnableMintableDeployer();
-                    tokenAddresses.seUSD = deployer.deploy("Savings Rate eUSD", "seUSD", STANDARD_DECIMALS);
-
-                    startBroadcast();
-                    console.log(
-                        "    Granting seUSD revoke minter role to the desired address %s", multisigAddresses.labs
-                    );
-                    bytes32 revokeMinterRole = ERC20BurnableMintable(tokenAddresses.seUSD).REVOKE_MINTER_ROLE();
-                    AccessControl(tokenAddresses.seUSD).grantRole(revokeMinterRole, multisigAddresses.labs);
-                    stopBroadcast();
-                }
-            } else {
-                console.log("! seUSD deployment deliberately skipped. Skipping...");
-            }
-        } else {
-            console.log("- seUSD already deployed. Skipping...");
-        }
-
-        if (bridgeAddresses.seusdOFTAdapter == address(0)) {
-            if (tokenAddresses.seUSD != address(0)) {
-                console.log("+ Deploying OFT Adapter for seUSD...");
-                bridgeAddresses.seusdOFTAdapter = deployOFTAdapter(tokenAddresses.seUSD, true);
-            } else {
-                console.log("! seUSD OFT Adapter deployment skipped. Skipping...");
-            }
-        } else {
-            console.log("- seUSD OFT Adapter already deployed. Skipping...");
-        }
-
-        if (
-            bridgeAddresses.seusdOFTAdapter != address(0)
-                && !containsOFTConfigIgnoreChainId(tokenAddresses.seUSD, block.chainid) && !getSkipOFTConfigSEUSD()
-        ) {
-            console.log("+ Attempting to configure OFT Adapter on chain %s for seUSD", block.chainid);
-            configureOFTAdapter(tokenAddresses.seUSD, bridgeAddresses.seusdOFTAdapter);
-        }
-
-        if (peripheryAddresses.feeCollector == address(0)) {
-            if (
-                tokenAddresses.eUSD != address(0) && bridgeAddresses.eusdOFTAdapter != address(0)
-                    && tokenAddresses.seUSD != address(0)
-            ) {
-                console.log("+ Deploying eUSD fee collecting system...");
-                if (block.chainid == HUB_CHAIN_ID) {
-                    startBroadcast();
-                    console.log("    Deploying OFTFeeCollectorGulper");
-                    peripheryAddresses.feeCollector =
-                        address(new OFTFeeCollectorGulper(coreAddresses.evc, getDeployer(), tokenAddresses.seUSD));
-                    stopBroadcast();
-                } else {
-                    startBroadcast();
-                    console.log("    Deploying OFTFeeCollector...");
-                    peripheryAddresses.feeCollector =
-                        address(new OFTFeeCollector(coreAddresses.evc, getDeployer(), tokenAddresses.eUSD));
-                    stopBroadcast();
-
-                    LayerZeroUtil lzUtil = new LayerZeroUtil(HUB_CHAIN_ID);
-                    LayerZeroUtil.DeploymentInfo memory infoOther = lzUtil.getDeploymentInfo(HUB_CHAIN_ID);
-                    address feeCollectorOther =
-                        deserializePeripheryAddresses(getAddressesJson("PeripheryAddresses.json", HUB_CHAIN_ID))
-                    .feeCollector;
-
-                    require(feeCollectorOther != address(0), "Hub chain feeCollector is not deployed yet");
-
-                    startBroadcast();
-                    console.log("    Configuring OFTFeeCollector");
-                    OFTFeeCollector(payable(peripheryAddresses.feeCollector))
-                        .configure(
-                            bridgeAddresses.eusdOFTAdapter, feeCollectorOther, infoOther.eid, abi.encode(true), ""
-                        );
-                    stopBroadcast();
-                }
-
-                startBroadcast();
-                console.log(
-                    "    Granting fee collector maintainer role to the desired address %s", multisigAddresses.labs
-                );
-                bytes32 maintainerRole = FeeCollectorUtil(peripheryAddresses.feeCollector).MAINTAINER_ROLE();
-                AccessControl(peripheryAddresses.feeCollector).grantRole(maintainerRole, multisigAddresses.labs);
-                stopBroadcast();
-            } else {
-                console.log("- eUSD fee collecting system not deployed. Skipping...");
-            }
-        } else {
-            console.log("- eUSD fee collecting system already deployed. Skipping...");
-        }
-
         if (
             peripheryAddresses.oracleRouterFactory == address(0) || peripheryAddresses.kinkIRMFactory == address(0)
                 || peripheryAddresses.kinkyIRMFactory == address(0)
@@ -570,14 +355,10 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
         }
 
         if (peripheryAddresses.feeFlowController == address(0)) {
-            address paymentToken = bridgeAddresses.eusdOFTAdapter != address(0)
-                ? tokenAddresses.eUSD
-                : bridgeAddresses.eulOFTAdapter != address(0) ? tokenAddresses.EUL : getWETHAddress();
+            address paymentToken = bridgeAddresses.eulOFTAdapter != address(0) ? tokenAddresses.EUL : getWETHAddress();
             address oftAdapter = block.chainid == HUB_CHAIN_ID
                 ? address(0)
-                : paymentToken == tokenAddresses.eUSD
-                    ? bridgeAddresses.eusdOFTAdapter
-                    : paymentToken == tokenAddresses.EUL ? bridgeAddresses.eulOFTAdapter : address(0);
+                : paymentToken == tokenAddresses.EUL ? bridgeAddresses.eulOFTAdapter : address(0);
 
             if (input.feeFlowInitPrice != 0 && paymentToken != address(0)) {
                 console.log("+ Deploying FeeFlowController...");
@@ -596,43 +377,10 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
                     dstEid: oftAdapter == address(0)
                         ? 0
                         : (new LayerZeroUtil(HUB_CHAIN_ID)).getDeploymentInfo(HUB_CHAIN_ID).eid,
-                    hookTarget: peripheryAddresses.feeCollector,
-                    hookTargetSelector: FeeCollectorUtil.collectFees.selector
+                    hookTarget: address(0),
+                    hookTargetSelector: bytes4(0)
                 });
                 peripheryAddresses.feeFlowController = deployer.deploy(feeFlowInput);
-
-                if (block.chainid != HUB_CHAIN_ID && peripheryAddresses.feeCollector != address(0)) {
-                    bytes32 defaultAdminRole =
-                        OFTFeeCollector(payable(peripheryAddresses.feeCollector)).DEFAULT_ADMIN_ROLE();
-                    bytes32 collectorRole = OFTFeeCollector(payable(peripheryAddresses.feeCollector)).COLLECTOR_ROLE();
-                    if (OFTFeeCollector(payable(peripheryAddresses.feeCollector))
-                            .hasRole(defaultAdminRole, getDeployer())) {
-                        vm.startBroadcast();
-                        console.log(
-                            "    Granting OFTFeeCollector collector role to the desired address %s",
-                            peripheryAddresses.feeFlowController
-                        );
-                        AccessControl(peripheryAddresses.feeCollector)
-                            .grantRole(collectorRole, peripheryAddresses.feeFlowController);
-                        stopBroadcast();
-                    } else if (OFTFeeCollector(payable(peripheryAddresses.feeCollector))
-                            .hasRole(defaultAdminRole, getSafe(false))) {
-                        console.log(
-                            "    Adding multisend item to grant OFTFeeCollector collector role to the desired address %s",
-                            peripheryAddresses.feeFlowController
-                        );
-                        addMultisendItem(
-                            peripheryAddresses.feeCollector,
-                            abi.encodeCall(
-                                AccessControl.grantRole, (collectorRole, peripheryAddresses.feeFlowController)
-                            )
-                        );
-                    } else {
-                        console.log(
-                            "    ! The deployer or designated safe no longer has the default admin role to grant the OFTFeeCollector collector role to the desired address. This must be done manually. Skipping..."
-                        );
-                    }
-                }
             } else {
                 console.log(
                     "! feeFlowInitPrice or paymentToken is not set for FeeFlowController deployment. Skipping..."
@@ -1189,10 +937,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
     function getTokenKey(address token) internal view returns (string memory) {
         if (token == tokenAddresses.EUL) {
             return "EUL";
-        } else if (token == tokenAddresses.eUSD) {
-            return "eUSD";
-        } else if (token == tokenAddresses.seUSD) {
-            return "seUSD";
         }
 
         revert("getTokenKey: Token not supported");
@@ -1204,10 +948,6 @@ contract CoreAndPeriphery is BatchBuilder, SafeMultisendBuilder {
 
         if (token == tokenAddresses.EUL) {
             adapter = chainIdBridgeAddresses.eulOFTAdapter;
-        } else if (token == tokenAddresses.eUSD) {
-            adapter = chainIdBridgeAddresses.eusdOFTAdapter;
-        } else if (token == tokenAddresses.seUSD) {
-            adapter = chainIdBridgeAddresses.seusdOFTAdapter;
         }
     }
 

--- a/script/51_OwnershipTransferCore.s.sol
+++ b/script/51_OwnershipTransferCore.s.sol
@@ -145,87 +145,10 @@ contract OwnershipTransferCore is BatchBuilder {
             console.log("- rEUL owner is already set to the desired address. Skipping...");
         }
 
-        if (tokenAddresses.eUSD != address(0)) {
-            transferERC20BurnableMintableOwnership(
-                "eUSD",
-                tokenAddresses.eUSD,
-                governorAddresses.eUSDAdminTimelockController == address(0)
-                    ? multisigAddresses.DAO
-                    : governorAddresses.eUSDAdminTimelockController
-            );
-        } else {
-            console.log("! eUSD is not deployed yet. Skipping...");
-        }
-
-        if (tokenAddresses.seUSD != address(0) && block.chainid != HUB_CHAIN_ID) {
-            transferERC20BurnableMintableOwnership("seUSD", tokenAddresses.seUSD, multisigAddresses.DAO);
-        } else {
-            console.log("! seUSD is not deployed yet. Skipping...");
-        }
-
         if (bridgeAddresses.eulOFTAdapter != address(0)) {
             transferOFTAdapterOwnership("EUL", bridgeAddresses.eulOFTAdapter);
         } else {
             console.log("! EUL OFT Adapter is not deployed yet. Skipping...");
-        }
-
-        if (bridgeAddresses.eusdOFTAdapter != address(0)) {
-            transferOFTAdapterOwnership("eUSD", bridgeAddresses.eusdOFTAdapter);
-        } else {
-            console.log("! eUSD OFT Adapter is not deployed yet. Skipping...");
-        }
-
-        if (bridgeAddresses.seusdOFTAdapter != address(0)) {
-            transferOFTAdapterOwnership("seUSD", bridgeAddresses.seusdOFTAdapter);
-        } else {
-            console.log("! seUSD OFT Adapter is not deployed yet. Skipping...");
-        }
-
-        if (governorAddresses.eUSDAdminTimelockController != address(0)) {
-            bytes32 defaultAdminRole = AccessControl(governorAddresses.eUSDAdminTimelockController).DEFAULT_ADMIN_ROLE();
-
-            if (AccessControl(governorAddresses.eUSDAdminTimelockController).hasRole(defaultAdminRole, getDeployer())) {
-                console.log(
-                    "+ Renouncing eUSDAdminTimelockController default admin role from the caller of this script %s",
-                    getDeployer()
-                );
-                startBroadcast();
-                AccessControl(governorAddresses.eUSDAdminTimelockController)
-                    .renounceRole(defaultAdminRole, getDeployer());
-                stopBroadcast();
-            } else {
-                console.log(
-                    "- The caller of this script is no longer the default admin of the eUSDAdminTimelockController. Skipping..."
-                );
-            }
-        }
-
-        if (peripheryAddresses.feeCollector != address(0)) {
-            bytes32 defaultAdminRole = AccessControl(peripheryAddresses.feeCollector).DEFAULT_ADMIN_ROLE();
-
-            startBroadcast();
-            if (!AccessControl(peripheryAddresses.feeCollector).hasRole(defaultAdminRole, multisigAddresses.DAO)) {
-                if (AccessControl(peripheryAddresses.feeCollector).hasRole(defaultAdminRole, getDeployer())) {
-                    console.log("+ Granting FeeCollector default admin role to address %s", multisigAddresses.DAO);
-                    AccessControl(peripheryAddresses.feeCollector).grantRole(defaultAdminRole, multisigAddresses.DAO);
-                } else {
-                    console.log("! FeeCollector default admin role is not the caller of this script. Skipping...");
-                }
-            } else {
-                console.log("- FeeCollector default admin role is already set to the desired address. Skipping...");
-            }
-
-            if (AccessControl(peripheryAddresses.feeCollector).hasRole(defaultAdminRole, getDeployer())) {
-                console.log(
-                    "+ Renouncing FeeCollector default admin role from the caller of this script %s", getDeployer()
-                );
-                AccessControl(peripheryAddresses.feeCollector).renounceRole(defaultAdminRole, getDeployer());
-            } else {
-                console.log("- The caller of this script is no longer the default admin of FeeCollector. Skipping...");
-            }
-            stopBroadcast();
-        } else {
-            console.log("! FeeCollector is not deployed yet. Skipping...");
         }
 
         executeBatch();
@@ -262,7 +185,7 @@ contract OwnershipTransferCore is BatchBuilder {
     function transferOFTAdapterOwnership(string memory tokenName, address adapter) internal {
         address privilegedAddress;
 
-        if (block.chainid == HUB_CHAIN_ID && (_strEq(tokenName, "EUL") || _strEq(tokenName, "seUSD"))) {
+        if (block.chainid == HUB_CHAIN_ID && _strEq(tokenName, "EUL")) {
             address proxyAdmin = address(
                 uint160(uint256(vm.load(adapter, 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103)))
             );

--- a/script/README.md
+++ b/script/README.md
@@ -216,7 +216,7 @@ Redeploy lens contracts and update addresses.
 
 | Option | Description |
 |--------|-------------|
-| `--timelock-address <ADDR>` | Schedule transactions via timelock instead of immediate execution. Aliases: `admin`, `wildcard`, `eusd` |
+| `--timelock-address <ADDR>` | Schedule transactions via timelock instead of immediate execution. Aliases: `admin`, `wildcard` |
 | `--timelock-id <ID>` | Operation ID for executing a scheduled timelock transaction (from `CallScheduled` event) |
 | `--timelock-salt <SALT>` | Salt for timelock operation (default: zero) |
 
@@ -302,7 +302,6 @@ Deploys and configures the complete Euler V2 stack. The script prompts for:
 - Deploy EUL OFT Adapter (y/n)
 - Deploy Euler Earn (y/n)
 - Deploy EulerSwap V2 (y/n) — if yes, prompts for Uniswap V4 Pool Manager
-- Deploy eUSD/seUSD contracts (y/n)
 
 ```sh
 ./script/interactiveDeployment.sh --account ACC_NAME --rpc-url RPC_URL

--- a/script/interactiveDeployment.sh
+++ b/script/interactiveDeployment.sh
@@ -1291,8 +1291,6 @@ while true; do
                 feeFlowController=$(jq -r '.feeFlowController' "$addresses_dir_path/PeripheryAddresses.json" 2>/dev/null)
                 securitizeFactory=$(jq -r '.securitizeFactory' "$addresses_dir_path/PeripheryAddresses.json" 2>/dev/null)
                 eulOFTAdapter=$(jq -r '.eulOFTAdapter' "$addresses_dir_path/BridgeAddresses.json" 2>/dev/null)
-                eusdOFTAdapter=$(jq -r '.eusdOFTAdapter' "$addresses_dir_path/BridgeAddresses.json" 2>/dev/null)
-                seusdOFTAdapter=$(jq -r '.seusdOFTAdapter' "$addresses_dir_path/BridgeAddresses.json" 2>/dev/null)
                 eulerEarnFactory=$(jq -r '.eulerEarnFactory' "$addresses_dir_path/CoreAddresses.json" 2>/dev/null)
                 eulerEarnFactory=${eulerEarnFactory:-$addressZero}
                 eulerSwapV2Factory=$(jq -r '.eulerSwapV2Factory' "$addresses_dir_path/EulerSwapAddresses.json" 2>/dev/null)
@@ -1357,20 +1355,6 @@ while true; do
                 fi
             fi
 
-            if [ -z "$eusdOFTAdapter" ] || [ "$eusdOFTAdapter" == "$addressZero" ] || [ "$eusdOFTAdapter" == "null" ]; then
-                if [ "$non_interactive" = false ]; then
-                    read -p "Should deploy and configure eUSD contracts system? (y/n) (default: n): " deploy_eusd
-                    deploy_eusd=$(echo "$deploy_eusd" | tr "[:upper:]" "[:lower:]")
-                fi
-            fi
-
-            if [ -z "$seusdOFTAdapter" ] || [ "$seusdOFTAdapter" == "$addressZero" ] || [ "$seusdOFTAdapter" == "null" ]; then
-                if [ "$non_interactive" = false ]; then
-                    read -p "Should deploy and configure seUSD contracts system? (y/n) (default: n): " deploy_seusd
-                    deploy_seusd=$(echo "$deploy_seusd" | tr "[:upper:]" "[:lower:]")
-                fi
-            fi
-
             if [ -z "$securitizeFactory" ] || [ "$securitizeFactory" == "$addressZero" ] || [ "$securitizeFactory" == "null" ]; then
                 if [ "$non_interactive" = false ]; then
                     read -p "Should deploy Securitize Vault Factory? (y/n) (default: n): " deploy_securitize_factory
@@ -1390,8 +1374,6 @@ while true; do
             deploy_eul_oft=${deploy_eul_oft:-n}
             deploy_euler_earn=${deploy_euler_earn:-n}
             deploy_euler_swap=${deploy_euler_swap:-n}
-            deploy_eusd=${deploy_eusd:-n}
-            deploy_seusd=${deploy_seusd:-n}
             deploy_securitize_factory=${deploy_securitize_factory:-n}
             uniswap_pool_manager=${uniswap_pool_manager:-$addressZero}
             euler_swap_protocol_fee_config_admin=${euler_swap_protocol_fee_config_admin:-$multisig_dao}
@@ -1426,8 +1408,6 @@ while true; do
                 --argjson deployEULOFT "$(jq -n --argjson val \"$deploy_eul_oft\" 'if $val == "y" then true else false end')" \
                 --argjson deployEulerEarn "$(jq -n --argjson val \"$deploy_euler_earn\" 'if $val == "y" then true else false end')" \
                 --argjson deployEulerSwap "$(jq -n --argjson val \"$deploy_euler_swap\" 'if $val == "y" then true else false end')" \
-                --argjson deployEUSD "$(jq -n --argjson val \"$deploy_eusd\" 'if $val == "y" then true else false end')" \
-                --argjson deploySEUSD "$(jq -n --argjson val \"$deploy_seusd\" 'if $val == "y" then true else false end')" \
                 --argjson deploySecuritizeFactory "$(jq -n --argjson val \"$deploy_securitize_factory\" 'if $val == "y" then true else false end')" \
                 --arg uniswapPoolManager "$uniswap_pool_manager" \
                 --arg eulerSwapProtocolFeeConfigAdmin "$euler_swap_protocol_fee_config_admin" \
@@ -1445,8 +1425,6 @@ while true; do
                     deployEULOFT: $deployEULOFT,
                     deployEulerEarn: $deployEulerEarn,
                     deployEulerSwap: $deployEulerSwap,
-                    deployEUSD: $deployEUSD,
-                    deploySEUSD: $deploySEUSD,
                     deploySecuritizeFactory: $deploySecuritizeFactory,
                     uniswapPoolManager: $uniswapPoolManager,
                     eulerSwapProtocolFeeConfigAdmin: $eulerSwapProtocolFeeConfigAdmin,

--- a/script/production/CustomScripts.s.sol
+++ b/script/production/CustomScripts.s.sol
@@ -21,7 +21,6 @@ import {
     LensUtilsDeployer,
     LensEulerEarnVaultDeployer
 } from "../08_Lenses.s.sol";
-import {ERC20Synth} from "../../src/ERC20/deployed/ERC20Synth.sol";
 import {VaultLens, VaultInfoFull} from "../../src/Lens/VaultLens.sol";
 import {UtilsLens, VaultInfoERC4626} from "../../src/Lens/UtilsLens.sol";
 import {AccountLens, AccountInfo, AccountMultipleVaultsInfo} from "../../src/Lens/AccountLens.sol";
@@ -505,37 +504,3 @@ contract LiquidateAccount is BatchBuilder {
     }
 }
 
-contract eUSDAllocate is BatchBuilder {
-    function run(address vault, uint256 amount) public {
-        execute(vault, uint128(amount));
-    }
-
-    function execute(address vault, uint128 amount) internal {
-        bytes32 allocatorRole = ERC20Synth(tokenAddresses.eUSD).ALLOCATOR_ROLE();
-        bool isAllocator = ERC20Synth(tokenAddresses.eUSD).hasRole(allocatorRole, getAppropriateOnBehalfOfAccount());
-
-        addBatchItem(
-            tokenAddresses.eUSD, abi.encodeCall(ERC20Synth.setCapacity, (getAppropriateOnBehalfOfAccount(), amount))
-        );
-
-        addBatchItem(tokenAddresses.eUSD, abi.encodeCall(ERC20Synth.mint, (tokenAddresses.eUSD, amount)));
-
-        if (!isAllocator) {
-            addBatchItem(
-                tokenAddresses.eUSD,
-                abi.encodeCall(ERC20Synth.grantRole, (allocatorRole, getAppropriateOnBehalfOfAccount()))
-            );
-        }
-
-        addBatchItem(tokenAddresses.eUSD, abi.encodeCall(ERC20Synth.allocate, (vault, amount)));
-
-        if (!isAllocator) {
-            addBatchItem(
-                tokenAddresses.eUSD,
-                abi.encodeCall(ERC20Synth.revokeRole, (allocatorRole, getAppropriateOnBehalfOfAccount()))
-            );
-        }
-
-        executeBatch();
-    }
-}

--- a/script/production/README.md
+++ b/script/production/README.md
@@ -96,7 +96,7 @@ After governance transferred to GovernorAccessControl + TimelockController + Saf
 | `--account <NAME>` / `--ledger` | Signing method |
 | `--batch-via-safe` | Route transactions through Safe multisig |
 | `--safe-address <ADDR>` | Safe address or alias (`DAO`, `labs`, etc.) |
-| `--timelock-address <ADDR>` | Schedule via timelock (`admin`, `wildcard`, `eusd`) |
+| `--timelock-address <ADDR>` | Schedule via timelock (`admin`, `wildcard`) |
 | `--risk-steward-address <ADDR>` | Bypass timelock for caps/IRM changes |
 
 ### Simulation Options

--- a/script/utils/ScriptExtended.s.sol
+++ b/script/utils/ScriptExtended.s.sol
@@ -119,8 +119,6 @@ abstract contract ScriptExtended is Script {
                 timelockAddress = "accessControlEmergencyGovernorAdminTimelockController";
             } else if (_strEq(timelockAddress, "wildcard") || _strEq(timelockAddress, "Wildcard")) {
                 timelockAddress = "accessControlEmergencyGovernorWildcardTimelockController";
-            } else if (_strEq(timelockAddress, "eusd") || _strEq(timelockAddress, "eUSD")) {
-                timelockAddress = "eUSDAdminTimelockController";
             }
 
             timelock =
@@ -254,14 +252,6 @@ abstract contract ScriptExtended is Script {
 
     function getSkipOFTConfigEUL() internal view returns (bool) {
         return _strEq(vm.envOr("skip_oft_config_eul", string("")), "--skip-oft-config-eul");
-    }
-
-    function getSkipOFTConfigEUSD() internal view returns (bool) {
-        return _strEq(vm.envOr("skip_oft_config_eusd", string("")), "--skip-oft-config-eusd");
-    }
-
-    function getSkipOFTConfigSEUSD() internal view returns (bool) {
-        return _strEq(vm.envOr("skip_oft_config_seusd", string("")), "--skip-oft-config-seusd");
     }
 
     function getCheckPhasedOutVaults() internal view returns (bool) {

--- a/script/utils/ScriptUtils.s.sol
+++ b/script/utils/ScriptUtils.s.sol
@@ -79,8 +79,6 @@ abstract contract PeripheryAddressesLib is ScriptExtended {
         address evkFactoryPerspective;
         address escrowedCollateralPerspective;
         address eulerEarnFactoryPerspective;
-        address edgeFactory;
-        address edgeFactoryPerspective;
         address termsOfUseSigner;
         address governorAccessControlEmergencyFactory;
         address capRiskStewardFactory;
@@ -108,8 +106,6 @@ abstract contract PeripheryAddressesLib is ScriptExtended {
         result = vm.serializeAddress(
             "peripheryAddresses", "eulerEarnFactoryPerspective", Addresses.eulerEarnFactoryPerspective
         );
-        result = vm.serializeAddress("peripheryAddresses", "edgeFactory", Addresses.edgeFactory);
-        result = vm.serializeAddress("peripheryAddresses", "edgeFactoryPerspective", Addresses.edgeFactoryPerspective);
         result = vm.serializeAddress("peripheryAddresses", "termsOfUseSigner", Addresses.termsOfUseSigner);
         result = vm.serializeAddress(
             "peripheryAddresses",
@@ -137,8 +133,6 @@ abstract contract PeripheryAddressesLib is ScriptExtended {
             evkFactoryPerspective: getAddressFromJson(json, ".evkFactoryPerspective"),
             escrowedCollateralPerspective: getAddressFromJson(json, ".escrowedCollateralPerspective"),
             eulerEarnFactoryPerspective: getAddressFromJson(json, ".eulerEarnFactoryPerspective"),
-            edgeFactory: getAddressFromJson(json, ".edgeFactory"),
-            edgeFactoryPerspective: getAddressFromJson(json, ".edgeFactoryPerspective"),
             termsOfUseSigner: getAddressFromJson(json, ".termsOfUseSigner"),
             governorAccessControlEmergencyFactory: getAddressFromJson(json, ".governorAccessControlEmergencyFactory"),
             capRiskStewardFactory: getAddressFromJson(json, ".capRiskStewardFactory"),

--- a/script/utils/ScriptUtils.s.sol
+++ b/script/utils/ScriptUtils.s.sol
@@ -75,7 +75,6 @@ abstract contract PeripheryAddressesLib is ScriptExtended {
         address swapVerifier;
         address feeFlowController;
         address feeFlowControllerUtil;
-        address feeCollector;
         address evkFactoryPerspective;
         address escrowedCollateralPerspective;
         address eulerEarnFactoryPerspective;
@@ -98,7 +97,6 @@ abstract contract PeripheryAddressesLib is ScriptExtended {
         result = vm.serializeAddress("peripheryAddresses", "swapVerifier", Addresses.swapVerifier);
         result = vm.serializeAddress("peripheryAddresses", "feeFlowController", Addresses.feeFlowController);
         result = vm.serializeAddress("peripheryAddresses", "feeFlowControllerUtil", Addresses.feeFlowControllerUtil);
-        result = vm.serializeAddress("peripheryAddresses", "feeCollector", Addresses.feeCollector);
         result = vm.serializeAddress("peripheryAddresses", "evkFactoryPerspective", Addresses.evkFactoryPerspective);
         result = vm.serializeAddress(
             "peripheryAddresses", "escrowedCollateralPerspective", Addresses.escrowedCollateralPerspective
@@ -129,7 +127,6 @@ abstract contract PeripheryAddressesLib is ScriptExtended {
             swapVerifier: getAddressFromJson(json, ".swapVerifier"),
             feeFlowController: getAddressFromJson(json, ".feeFlowController"),
             feeFlowControllerUtil: getAddressFromJson(json, ".feeFlowControllerUtil"),
-            feeCollector: getAddressFromJson(json, ".feeCollector"),
             evkFactoryPerspective: getAddressFromJson(json, ".evkFactoryPerspective"),
             escrowedCollateralPerspective: getAddressFromJson(json, ".escrowedCollateralPerspective"),
             eulerEarnFactoryPerspective: getAddressFromJson(json, ".eulerEarnFactoryPerspective"),
@@ -181,7 +178,6 @@ abstract contract GovernorAddressesLib is ScriptExtended {
         address accessControlEmergencyGovernorAdminTimelockController;
         address accessControlEmergencyGovernorWildcardTimelockController;
         address capRiskSteward;
-        address eUSDAdminTimelockController;
     }
 
     function serializeGovernorAddresses(GovernorAddresses memory Addresses) internal returns (string memory result) {
@@ -203,9 +199,6 @@ abstract contract GovernorAddressesLib is ScriptExtended {
             Addresses.accessControlEmergencyGovernorWildcardTimelockController
         );
         result = vm.serializeAddress("governorAddresses", "capRiskSteward", Addresses.capRiskSteward);
-        result = vm.serializeAddress(
-            "governorAddresses", "eUSDAdminTimelockController", Addresses.eUSDAdminTimelockController
-        );
     }
 
     function deserializeGovernorAddresses(string memory json) internal pure returns (GovernorAddresses memory) {
@@ -219,8 +212,7 @@ abstract contract GovernorAddressesLib is ScriptExtended {
             accessControlEmergencyGovernorWildcardTimelockController: getAddressFromJson(
                 json, ".accessControlEmergencyGovernorWildcardTimelockController"
             ),
-            capRiskSteward: getAddressFromJson(json, ".capRiskSteward"),
-            eUSDAdminTimelockController: getAddressFromJson(json, ".eUSDAdminTimelockController")
+            capRiskSteward: getAddressFromJson(json, ".capRiskSteward")
         });
     }
 }
@@ -229,24 +221,15 @@ abstract contract TokenAddressesLib is ScriptExtended {
     struct TokenAddresses {
         address EUL;
         address rEUL;
-        address eUSD;
-        address seUSD;
     }
 
     function serializeTokenAddresses(TokenAddresses memory Addresses) internal returns (string memory result) {
         result = vm.serializeAddress("tokenAddresses", "EUL", Addresses.EUL);
         result = vm.serializeAddress("tokenAddresses", "rEUL", Addresses.rEUL);
-        result = vm.serializeAddress("tokenAddresses", "eUSD", Addresses.eUSD);
-        result = vm.serializeAddress("tokenAddresses", "seUSD", Addresses.seUSD);
     }
 
     function deserializeTokenAddresses(string memory json) internal pure returns (TokenAddresses memory) {
-        return TokenAddresses({
-            EUL: getAddressFromJson(json, ".EUL"),
-            rEUL: getAddressFromJson(json, ".rEUL"),
-            eUSD: getAddressFromJson(json, ".eUSD"),
-            seUSD: getAddressFromJson(json, ".seUSD")
-        });
+        return TokenAddresses({EUL: getAddressFromJson(json, ".EUL"), rEUL: getAddressFromJson(json, ".rEUL")});
     }
 }
 
@@ -338,22 +321,14 @@ abstract contract EulerSwapAddressesLib is ScriptExtended {
 abstract contract BridgeAddressesLib is ScriptExtended {
     struct BridgeAddresses {
         address eulOFTAdapter;
-        address eusdOFTAdapter;
-        address seusdOFTAdapter;
     }
 
     function serializeBridgeAddresses(BridgeAddresses memory Addresses) internal returns (string memory result) {
         result = vm.serializeAddress("bridgeAddresses", "eulOFTAdapter", Addresses.eulOFTAdapter);
-        result = vm.serializeAddress("bridgeAddresses", "eusdOFTAdapter", Addresses.eusdOFTAdapter);
-        result = vm.serializeAddress("bridgeAddresses", "seusdOFTAdapter", Addresses.seusdOFTAdapter);
     }
 
     function deserializeBridgeAddresses(string memory json) internal pure returns (BridgeAddresses memory) {
-        return BridgeAddresses({
-            eulOFTAdapter: getAddressFromJson(json, ".eulOFTAdapter"),
-            eusdOFTAdapter: getAddressFromJson(json, ".eusdOFTAdapter"),
-            seusdOFTAdapter: getAddressFromJson(json, ".seusdOFTAdapter")
-        });
+        return BridgeAddresses({eulOFTAdapter: getAddressFromJson(json, ".eulOFTAdapter")});
     }
 }
 

--- a/script/utils/executeForgeScript.sh
+++ b/script/utils/executeForgeScript.sh
@@ -146,16 +146,6 @@ if [[ "$@" == *"--skip-oft-config-eul"* ]]; then
     skip_oft_config_eul="--skip-oft-config-eul"
 fi
 
-if [[ "$@" == *"--skip-oft-config-eusd"* ]]; then
-    set -- "${@/--skip-oft-config-eusd/}"
-    skip_oft_config_eusd="--skip-oft-config-eusd"
-fi
-
-if [[ "$@" == *"--skip-oft-config-seusd"* ]]; then
-    set -- "${@/--skip-oft-config-seusd/}"
-    skip_oft_config_seusd="--skip-oft-config-seusd"
-fi
-
 if [[ "$@" == *"--check-phased-out-vaults"* ]]; then
     set -- "${@/--check-phased-out-vaults/}"
     check_phased_out_vaults="--check-phased-out-vaults"
@@ -268,8 +258,7 @@ if ! env broadcast=$broadcast safe_address=$safe_address safe_nonce=$safe_nonce 
     emergency_ltv_collateral=$emergency_ltv_collateral emergency_ltv_borrowing=$emergency_ltv_borrowing \
     emergency_caps=$emergency_caps emergency_operations=$emergency_operations \
     vault_address=$vault_address no_stub_oracle=$no_stub_oracle force_zero_oracle=$force_zero_oracle \
-    skip_oft_config_eul=$skip_oft_config_eul skip_oft_config_eusd=$skip_oft_config_eusd \
-    skip_oft_config_seusd=$skip_oft_config_seusd \
+    skip_oft_config_eul=$skip_oft_config_eul \
     check_phased_out_vaults=$check_phased_out_vaults \
     from_block=$from_block to_block=$to_block source_wallet=$source_wallet destination_wallet=$destination_wallet \
     source_account_id=$source_account_id destination_account_id=$destination_account_id \


### PR DESCRIPTION
## Summary

Stacked on #429. Deploy-only removal: `50_CoreAndPeriphery` no longer deploys the GovernorAccessControlEmergency suite (governor + admin/wildcard timelocks), the CapRiskSteward, the EdgeFactory or the EdgeFactoryPerspective on new chains, and the `edgeFactory`/`edgeFactoryPerspective` fields are dropped from the `PeripheryAddresses` struct to match the address book.

Everything needed to manage existing chains and to deploy these contracts manually stays untouched:
- GovernorAddresses struct fields and JSON keys (`accessControlEmergencyGovernor`, both timelocks, `capRiskSteward`)
- the `--timelock-address admin|wildcard` and `--risk-steward-address` CLI aliases and all cluster management scripts
- the governor factories (still deployed on new chains)
- the standalone deployer scripts (`12_Governor`, `15_EdgeFactory`, Edge perspectives, `DeployAndConfigureCRSAndGACE`) and their interactive menu entries

## Test plan
- [x] `forge build` clean
- [x] `forge test` (non-fork): 450 passed on the stack